### PR TITLE
Add a "Don't start experiments" mode to the script

### DIFF
--- a/minikube_demo_setup.sh
+++ b/minikube_demo_setup.sh
@@ -263,6 +263,7 @@ function get_urls() {
 	echo "#              Autotune               #"
 	echo "#######################################"
 	echo "Info: Access Autotune tunables at http://${MINIKUBE_IP}:${AUTOTUNE_PORT}/listAutotuneTunables"
+	echo "######  The following links are meaningful only after an autotune object is deployed ######"
 	echo "Info: Autotune is monitoring these apps http://${MINIKUBE_IP}:${AUTOTUNE_PORT}/listApplications"
 	echo "Info: List Layers in apps that Autotune is monitoring http://${MINIKUBE_IP}:${AUTOTUNE_PORT}/listAppLayers"
 	echo "Info: List Tunables in apps that Autotune is monitoring http://${MINIKUBE_IP}:${AUTOTUNE_PORT}/listAppTunables"


### PR DESCRIPTION
This will enable manually starting them. This is useful in a demo scenario which will help the person doing the demo to have better control.