### PR TITLE
Use demo manifests to include resources

### DIFF
--- a/common/common_helper.sh
+++ b/common/common_helper.sh
@@ -251,27 +251,23 @@ function benchmarks_install() {
 # Start a background load on the benchmark for 20 mins
 #
 function apply_benchmark_load() {
-	if [ ${benchmark_load} -eq 0 ]; then
-		return;
-	fi
-
-	echo
-	echo "###################################################################"
-	echo " Starting 20 min background load against the techempower benchmark "
-	echo "###################################################################"
-	echo
-
 	TECHEMPOWER_LOAD_IMAGE="quay.io/kruizehub/tfb_hyperfoil_load:0.25.2"
 	APP_NAMESPACE="${1:-default}"
-	# 20 mins = 1200 seconds
-	# LOAD_DURATION=1200
+	LOAD_DURATION="${2:-1200}"
+
+	echo
+	echo "################################################################################################################"
+	echo " Starting ${LOAD_DURATION} secs background load against the techempower benchmark in ${APP_NAMESPACE} namespace "
+	echo "################################################################################################################"
+	echo
+
 	if [ ${CLUSTER_TYPE} == "minikube" ]; then
 		TECHEMPOWER_ROUTE=${TECHEMPOWER_URL}
 	elif [ ${CLUSTER_TYPE} == "openshift" ]; then
 		TECHEMPOWER_ROUTE=$(oc get route -n ${APP_NAMESPACE} --template='{{range .items}}{{.spec.host}}{{"\n"}}{{end}}')
 	fi
 	# docker run -d --rm --network="host"  ${TECHEMPOWER_LOAD_IMAGE} /opt/run_hyperfoil_load.sh ${TECHEMPOWER_ROUTE} <END_POINT> <DURATION> <THREADS> <CONNECTIONS>
-	docker run -d --rm --network="host"  ${TECHEMPOWER_LOAD_IMAGE} /opt/run_hyperfoil_load.sh ${TECHEMPOWER_ROUTE} queries?queries=20 1200 1024 8096
+	podman run -d --rm --network="host"  ${TECHEMPOWER_LOAD_IMAGE} /opt/run_hyperfoil_load.sh ${TECHEMPOWER_ROUTE} queries?queries=20 ${LOAD_DURATION} 1024 8096
 
 }
 
@@ -300,11 +296,12 @@ function check_minikube() {
 #   Deploy TFB Benchmarks - multiple import
 ###########################################
 function create_namespace() {
+	CAPP_NAMESPACE="${1:-test-multiple-import}"
 	echo
-	echo "#######################################"
-	echo "Creating new namespace: test-multiple-import"
-  	kubectl create namespace test-multiple-import
-	echo "#######################################"
+	echo "#########################################"
+	echo "Creating new namespace: ${CAPP_NAMESPACE}"
+  	kubectl create namespace ${CAPP_NAMESPACE}
+	echo "#########################################"
 	echo
 }
 

--- a/common/common_helper.sh
+++ b/common/common_helper.sh
@@ -233,12 +233,13 @@ function prometheus_install() {
 ###########################################
 function benchmarks_install() {
   	NAMESPACE="${1:-default}"
+	MANIFESTS="${2:-default_manifests}"
 	echo
 	echo "#######################################"
 	pushd benchmarks >/dev/null
 		echo "5. Installing TechEmpower (Quarkus REST EASY) benchmark into cluster"
 		pushd techempower >/dev/null
-		kubectl apply -f manifests/default_manifests -n ${NAMESPACE}
+		kubectl apply -f manifests/${MANIFESTS} -n ${NAMESPACE}
 		check_err "ERROR: TechEmpower app failed to start, exiting"
 		popd >/dev/null
 	popd >/dev/null

--- a/common/common_helper.sh
+++ b/common/common_helper.sh
@@ -267,7 +267,7 @@ function apply_benchmark_load() {
 		TECHEMPOWER_ROUTE=$(oc get route -n ${APP_NAMESPACE} --template='{{range .items}}{{.spec.host}}{{"\n"}}{{end}}')
 	fi
 	# docker run -d --rm --network="host"  ${TECHEMPOWER_LOAD_IMAGE} /opt/run_hyperfoil_load.sh ${TECHEMPOWER_ROUTE} <END_POINT> <DURATION> <THREADS> <CONNECTIONS>
-	podman run -d --rm --network="host"  ${TECHEMPOWER_LOAD_IMAGE} /opt/run_hyperfoil_load.sh ${TECHEMPOWER_ROUTE} queries?queries=20 ${LOAD_DURATION} 1024 8096
+	docker run -d --rm --network="host"  ${TECHEMPOWER_LOAD_IMAGE} /opt/run_hyperfoil_load.sh ${TECHEMPOWER_ROUTE} queries?queries=20 ${LOAD_DURATION} 1024 8096
 
 }
 

--- a/common/common_helper.sh
+++ b/common/common_helper.sh
@@ -238,8 +238,8 @@ function benchmarks_install() {
 	pushd benchmarks >/dev/null
 		echo "5. Installing TechEmpower (Quarkus REST EASY) benchmark into cluster"
 		pushd techempower >/dev/null
-			kubectl apply -f manifests/default_manifests -n ${NAMESPACE}
-			check_err "ERROR: TechEmpower app failed to start, exiting"
+		kubectl apply -f manifests/default_manifests -n ${NAMESPACE}
+		check_err "ERROR: TechEmpower app failed to start, exiting"
 		popd >/dev/null
 	popd >/dev/null
 	echo "#######################################"

--- a/monitoring/local_monitoring/ReadMe.md
+++ b/monitoring/local_monitoring/ReadMe.md
@@ -1,6 +1,6 @@
-# Local Monitoring with Kruize-Autotune
+# Local Monitoring with Kruize
 
-With Kruize-Autotune's local monitoring mode, we'll explore a demonstration of local monitoring on OpenShift, highlighting how it provides customized recommendations for various load scenarios.
+With Kruize's local monitoring mode, let's explore a demonstration of local monitoring, highlighting how it provides customized recommendations for various load scenarios in Openshift.
 
 ## Getting Started with the Demo
 
@@ -30,7 +30,7 @@ This demo focuses on using the TFB (TechEmpower Framework Benchmarks) benchmark 
       - tfb-qrh: Serving as the application server.
       - tfb-database: Database to the server.
 - Install Kruize
-  - Installs kruze under openshift-tuning name.
+  - Installs kruize under openshift-tuning name.
 - Metadata Collection and Experiment Creation
   - Kruize gathers data sources and metadata from the cluster.
   - Experiments `monitor_tfb_benchmark` and `monitor_tfb-db_benchmark` are created for the server and database deployments respectively in the `default` namespace.

--- a/monitoring/local_monitoring/ReadMe.md
+++ b/monitoring/local_monitoring/ReadMe.md
@@ -1,0 +1,68 @@
+# Local Monitoring with Kruize-Autotune
+
+With Kruize-Autotune's local monitoring mode, we'll explore a demonstration of local monitoring on OpenShift, highlighting how it provides customized recommendations for various load scenarios.
+
+## Getting Started with the Demo
+
+To begin exploring local monitoring capabilities, follow these steps:
+
+### Run the Demo
+
+##### Clone the demo repository:
+```sh
+git clone git@github.com:kruize/kruize-demos.git
+```
+##### Change directory to the local monitoring demo:
+```sh
+cd kruize-demos/monitoring/local_monitoring
+```
+##### Execute the demo script in openshift as: 
+```sh
+./local_monitoring_demo.sh -c openshift
+```
+
+## Understanding the Demo
+
+This demo focuses on using the TFB (TechEmpower Framework Benchmarks) benchmark to simulate different load conditions and observe how Kruize-Autotune reacts with its recommendations. Here’s a breakdown of what happens during the demo:
+
+- TFB deployment in default Namespace
+    - The TFB benchmark is initially deployed in the default namespace, comprising two key deployments
+      - tfb-qrh: Serving as the application server.
+      - tfb-database: Database to the server.
+- Install Kruize
+  - Installs kruze under openshift-tuning name.
+- Metadata Collection and Experiment Creation
+  - Kruize gathers data sources and metadata from the cluster.
+  - Experiments `monitor_tfb_benchmark` and `monitor_tfb-db_benchmark` are created for the server and database deployments respectively in the `default` namespace.
+- Creating a New Namespace and Application deployment
+  - A new namespace named test-multiple-import is created.
+  - The TFB benchmark is deployed in the test-multiple-import namespace.
+  - Load is applied to the server for 20 mins within this namespace to simulate real-world usage scenarios.
+- Metadata Refresh and Experiment Setup
+  - Kruize updates its metadata to include the test-multiple-import namespace.
+  - New experiments `monitor_tfb_benchmark_multiple_import` and `monitor_tfb-db_benchmark_multiple_import` are created for the server and database deployments in `test-multiple-import` namespace.
+- Generate Recommendations
+  - Generates Recommendations for all the experiments created.
+
+## Recommendations for different load Simulations observed on Openshift
+### IDLE 
+- Experiment: `monitor_tfb-db_benchmark`
+  - Shows an IDLE scenario where CPU recommendations are not generated due to minimal CPU usage (less than a millicore).
+  ![idle](https://github.com/kusumachalasani/autotune-demo/assets/17760990/9e1505ca-6c75-4da7-a154-3c6ed3adf3ed)
+### Over Provision
+- Experiment: `monitor_tfb_benchmark_multiple_import`
+  - Highlights over-provisioning where CPU recommendations are lower than the current CPU requests. This scenario also demonstrates over-provisioning in memory usage.
+  ![overprovision](https://github.com/kusumachalasani/autotune-demo/assets/17760990/9aac1d35-0e4b-44c6-b358-5eaf00c2852d)
+### Under Provision
+- Experiment: `monitor_tfb-db_benchmark_multiple_import`
+  - Illustrates under-provisioning where CPU recommendations exceed the current CPU requests, suggesting adjustments for improved efficiency.
+  ![underprovision](https://github.com/kusumachalasani/autotune-demo/assets/17760990/9005a59d-db4c-41b4-b170-90adf0fafff0)
+
+## Misc
+
+##### To apply the load to TFB benchmark: 
+```sh
+./local_monitoring_demo.sh -c openshift -l -n <APP_NAMESPACE> -d <LOAD_DURATION>
+./local_monitoring_demo.sh -c openshift -l -n "test-multiple-import" -d "1200"
+```
+  

--- a/monitoring/local_monitoring/local_monitoring_demo.sh
+++ b/monitoring/local_monitoring/local_monitoring_demo.sh
@@ -26,14 +26,11 @@ export KRUIZE_DOCKER_REPO="quay.io/kruize/autotune_operator"
 # Default cluster
 export CLUSTER_TYPE="minikube"
 
-# Default duration of benchmark warmup/measurement cycles in seconds.
-export DURATION=60
-
 # Target mode, default "crc"; "autotune" is currently broken
 export target="crc"
 
 function usage() {
-	echo "Usage: $0 [-s|-t] [-c cluster-type] [l] [-p] [-r] [-i kruize-image] [-u kruize-ui-image]"
+	echo "Usage: $0 [-s|-t] [-c cluster-type] [-l] [-p] [-r] [-i kruize-image] [-u kruize-ui-image] [-b] [-n namespace] [-d load-duration] "
 	echo "c = supports minikube and openshift cluster-type"
 	echo "i = kruize image. Default - quay.io/kruize/autotune_operator:<version as in pom.xml>"
 	echo "l = Run a load against the benchmark"
@@ -41,6 +38,9 @@ function usage() {
 	echo "r = restart kruize only"
 	echo "s = start (default), t = terminate"
 	echo "u = Kruize UI Image. Default - quay.io/kruize/kruize-ui:<version as in package.json>"
+	echo "b = deploy the benchmark."
+	echo "n = namespace of benchmark. Default - default"
+	echo "d = duration to run the benchmark load"
 
 	exit 1
 }

--- a/monitoring/local_monitoring/local_monitoring_demo.sh
+++ b/monitoring/local_monitoring/local_monitoring_demo.sh
@@ -122,27 +122,6 @@ function kruize_local() {
 	echo
 
 	echo
-	echo "######################################################"
-	echo "#     Generate recommendations"
-	echo "######################################################"
-	echo
-	curl -X POST "http://${KRUIZE_URL}/generateRecommendations?experiment_name=monitor_tfb_benchmark"
-	curl -X POST "http://${KRUIZE_URL}/generateRecommendations?experiment_name=monitor_tfb-db_benchmark"
-	echo ""
-
-	echo
-	echo "######################################################"
-	echo
-	echo "Generate fresh recommendations using"
-	echo "curl -X POST http://${KRUIZE_URL}/generateRecommendations?experiment_name=monitor_tfb_benchmark"
-	echo
-	echo "List Recommendations using "
-	echo "curl http://${KRUIZE_URL}/listRecommendations?experiment_name=monitor_tfb_benchmark"
-	echo
-	echo "######################################################"
-	echo
-
-	echo
   	echo "######################################################"
   	echo "#     Delete previously imported metadata"
   	echo "######################################################"
@@ -198,7 +177,7 @@ function kruize_local() {
   	echo "##############################################################"
   	echo
   	create_namespace
-  	benchmarks_install "test-multiple-import"
+  	benchmarks_install "test-multiple-import" "resource_provisioning_manifests"
   	sleep 35
   	get_urls "test-multiple-import"
   	apply_benchmark_load "test-multiple-import"
@@ -247,11 +226,16 @@ function kruize_local() {
   	curl -X POST http://${KRUIZE_URL}/createExperiment -d @./create_tfb-db_exp_multiple_import.json
   	echo
 
+	echo "Sleeping for 3mins before generating the recommendations!"
+	sleep 3m
+
   	echo
   	echo "######################################################"
-  	echo "#     Generate recommendations"
+  	echo "#     Generate recommendations for every experiment"
   	echo "######################################################"
   	echo
+	curl -X POST "http://${KRUIZE_URL}/generateRecommendations?experiment_name=monitor_tfb_benchmark"
+	curl -X POST "http://${KRUIZE_URL}/generateRecommendations?experiment_name=monitor_tfb-db_benchmark"
   	curl -X POST "http://${KRUIZE_URL}/generateRecommendations?experiment_name=monitor_tfb_benchmark_multiple_import"
   	curl -X POST "http://${KRUIZE_URL}/generateRecommendations?experiment_name=monitor_tfb-db_benchmark_multiple_import"
   	echo ""
@@ -260,10 +244,16 @@ function kruize_local() {
   	echo "######################################################"
   	echo
   	echo "Generate fresh recommendations using"
+	echo "curl -X POST http://${KRUIZE_URL}/generateRecommendations?experiment_name=monitor_tfb_benchmark"
+	echo "curl -X POST http://${KRUIZE_URL}/generateRecommendations?experiment_name=monitor_tfb-db_benchmark"
   	echo "curl -X POST http://${KRUIZE_URL}/generateRecommendations?experiment_name=monitor_tfb_benchmark_multiple_import"
+	echo "curl -X POST http://${KRUIZE_URL}/generateRecommendations?experiment_name=monitor_tfb-db_benchmark_multiple_import"
   	echo
   	echo "List Recommendations using "
+	echo "curl http://${KRUIZE_URL}/listRecommendations?experiment_name=monitor_tfb_benchmark"
+	echo "curl http://${KRUIZE_URL}/listRecommendations?experiment_name=monitor_tfb-db_benchmark"
   	echo "curl http://${KRUIZE_URL}/listRecommendations?experiment_name=monitor_tfb_benchmark_multiple_import"
+	echo "curl http://${KRUIZE_URL}/listRecommendations?experiment_name=monitor_tfb-db_benchmark_multiple_import"
   	echo
   	echo "######################################################"
   	echo


### PR DESCRIPTION
While running the kruize local demo, we need to enable the resources to showcase different workload conditions.