### PR TITLE
Update local monitoring demos with multiple metadata imports

### DIFF
--- a/common/common_helper.sh
+++ b/common/common_helper.sh
@@ -301,7 +301,7 @@ function create_namespace_and_install_benchmarks() {
 	echo
 	echo "#######################################"
 	echo "Creating new namespace: test-multiple-import"
-  kubectl create namespace test-multiple-import
+  	kubectl create namespace test-multiple-import
 	echo "#######################################"
 	pushd benchmarks >/dev/null
 		pushd techempower >/dev/null

--- a/common/common_helper.sh
+++ b/common/common_helper.sh
@@ -232,12 +232,13 @@ function prometheus_install() {
 #   Benchmarks Install
 ###########################################
 function benchmarks_install() {
+  	NAMESPACE="${1:-default}"
 	echo
 	echo "#######################################"
 	pushd benchmarks >/dev/null
 		echo "5. Installing TechEmpower (Quarkus REST EASY) benchmark into cluster"
 		pushd techempower >/dev/null
-			kubectl apply -f manifests
+			kubectl apply -f manifests/default_manifests -n ${NAMESPACE}
 			check_err "ERROR: TechEmpower app failed to start, exiting"
 		popd >/dev/null
 	popd >/dev/null
@@ -297,19 +298,11 @@ function check_minikube() {
 ###########################################
 #   Deploy TFB Benchmarks - multiple import
 ###########################################
-function create_namespace_and_install_benchmarks() {
+function create_namespace() {
 	echo
 	echo "#######################################"
 	echo "Creating new namespace: test-multiple-import"
   	kubectl create namespace test-multiple-import
-	echo "#######################################"
-	pushd benchmarks >/dev/null
-		pushd techempower >/dev/null
-		  echo "Installing TechEmpower (Quarkus REST EASY) benchmark in new namespace"
-			kubectl apply -f manifests -n test-multiple-import
-			check_err "ERROR: TechEmpower app failed to start, exiting"
-		popd >/dev/null
-	popd >/dev/null
 	echo "#######################################"
 	echo
 }

--- a/common/common_helper.sh
+++ b/common/common_helper.sh
@@ -260,7 +260,7 @@ function apply_benchmark_load() {
 	echo
 
 	TECHEMPOWER_LOAD_IMAGE="quay.io/kruizehub/tfb_hyperfoil_load:0.25.2"
-	APP_NAMESPACE=default
+	APP_NAMESPACE="${1:-default}"
 	# 20 mins = 1200 seconds
 	# LOAD_DURATION=1200
 	if [ ${CLUSTER_TYPE} == "minikube" ]; then
@@ -292,5 +292,25 @@ function check_minikube() {
 		print_min_resources
 		exit 1
 	fi
+}
+
+###########################################
+#   Deploy TFB Benchmarks - multiple import
+###########################################
+function create_namespace_and_install_benchmarks() {
+	echo
+	echo "#######################################"
+	echo "Creating new namespace: test-multiple-import"
+  kubectl create namespace test-multiple-import
+	echo "#######################################"
+	pushd benchmarks >/dev/null
+		pushd techempower >/dev/null
+		  echo "Installing TechEmpower (Quarkus REST EASY) benchmark in new namespace"
+			kubectl apply -f manifests -n test-multiple-import
+			check_err "ERROR: TechEmpower app failed to start, exiting"
+		popd >/dev/null
+	popd >/dev/null
+	echo "#######################################"
+	echo
 }
 

--- a/monitoring/local_monitoring/create_tfb-db_exp_multiple_import.json
+++ b/monitoring/local_monitoring/create_tfb-db_exp_multiple_import.json
@@ -10,7 +10,7 @@
     {
       "type": "deployment",
       "name": "tfb-database",
-      "namespace": "default",
+      "namespace": "test-multiple-import",
       "containers": [
         {
           "container_image_name": "kruize/tfb-postgres-openshift:latest",

--- a/monitoring/local_monitoring/create_tfb-db_exp_multiple_import.json
+++ b/monitoring/local_monitoring/create_tfb-db_exp_multiple_import.json
@@ -1,0 +1,28 @@
+[{
+  "version": "v2.0",
+  "experiment_name": "monitor_tfb-db_benchmark_multiple_import",
+  "cluster_name": "default",
+  "performance_profile": "resource-optimization-openshift",
+  "mode": "monitor",
+  "target_cluster": "local",
+  "datasource": "prometheus-1",
+  "kubernetes_objects": [
+    {
+      "type": "deployment",
+      "name": "tfb-database",
+      "namespace": "default",
+      "containers": [
+        {
+          "container_image_name": "kruize/tfb-postgres-openshift:latest",
+          "container_name": "tfb-database"
+        }
+      ]
+    }
+  ],
+  "trial_settings": {
+    "measurement_duration": "15min"
+  },
+  "recommendation_settings": {
+    "threshold": "0.1"
+  }
+}]

--- a/monitoring/local_monitoring/create_tfb_exp_multiple_import.json
+++ b/monitoring/local_monitoring/create_tfb_exp_multiple_import.json
@@ -10,7 +10,7 @@
     {
       "type": "deployment",
       "name": "tfb-qrh-sample",
-      "namespace": "default",
+      "namespace": "test-multiple-import",
       "containers": [
         {
           "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",

--- a/monitoring/local_monitoring/create_tfb_exp_multiple_import.json
+++ b/monitoring/local_monitoring/create_tfb_exp_multiple_import.json
@@ -1,0 +1,28 @@
+[{
+  "version": "v2.0",
+  "experiment_name": "monitor_tfb_benchmark_multiple_import",
+  "cluster_name": "default",
+  "performance_profile": "resource-optimization-openshift",
+  "mode": "monitor",
+  "target_cluster": "local",
+  "datasource": "prometheus-1",
+  "kubernetes_objects": [
+    {
+      "type": "deployment",
+      "name": "tfb-qrh-sample",
+      "namespace": "default",
+      "containers": [
+        {
+          "container_image_name": "kruize/tfb-qrh:1.13.2.F_et17",
+          "container_name": "tfb-server"
+        }
+      ]
+    }
+  ],
+  "trial_settings": {
+    "measurement_duration": "15min"
+  },
+  "recommendation_settings": {
+    "threshold": "0.1"
+  }
+}]

--- a/monitoring/local_monitoring/local_monitoring_demo.sh
+++ b/monitoring/local_monitoring/local_monitoring_demo.sh
@@ -143,129 +143,129 @@ function kruize_local() {
 	echo
 
 	echo
-  echo "######################################################"
-  echo "#     Delete previously imported metadata"
-  echo "######################################################"
-  echo
-  curl -X DELETE http://"${KRUIZE_URL}"/dsmetadata \
+  	echo "######################################################"
+  	echo "#     Delete previously imported metadata"
+  	echo "######################################################"
+  	echo
+  	curl -X DELETE http://"${KRUIZE_URL}"/dsmetadata \
   	--header 'Content-Type: application/json' \
   	--data '{
   	   "version": "v1.0",
   	   "datasource_name": "prometheus-1"
   	}'
-  echo
+  	echo
 
-  echo
-  echo "######################################################"
-  echo "#     Display metadata from prometheus-1 datasource - 2nd iteration"
-  echo "######################################################"
-  echo
-  curl "http://${KRUIZE_URL}/dsmetadata?datasource=${DATASOURCE}&verbose=true"
-  echo
+  	echo
+  	echo "######################################################"
+  	echo "#     Display metadata from prometheus-1 datasource - 2nd iteration"
+  	echo "######################################################"
+  	echo
+  	curl "http://${KRUIZE_URL}/dsmetadata?datasource=${DATASOURCE}&verbose=true"
+  	echo
 
-  echo
-  echo "######################################################"
-  echo "#     Import metadata from prometheus-1 datasource - 2nd iteration"
-  echo "######################################################"
-  echo
-  curl --location http://"${KRUIZE_URL}"/dsmetadata \
-  --header 'Content-Type: application/json' \
-  --data '{
-     "version": "v1.0",
-     "datasource_name": "prometheus-1"
-  }'
+  	echo
+  	echo "######################################################"
+  	echo "#     Import metadata from prometheus-1 datasource - 2nd iteration"
+  	echo "######################################################"
+  	echo
+  	curl --location http://"${KRUIZE_URL}"/dsmetadata \
+  	--header 'Content-Type: application/json' \
+  	--data '{
+     	   "version": "v1.0",
+     	   "datasource_name": "prometheus-1"
+  	}'
 
 
-  echo
-  echo "######################################################"
-  echo "#     Display metadata from prometheus-1 datasource - 2nd iteration"
-  echo "######################################################"
-  echo
-  curl "http://${KRUIZE_URL}/dsmetadata?datasource=${DATASOURCE}&verbose=true"
-  echo
+  	echo
+  	echo "######################################################"
+  	echo "#     Display metadata from prometheus-1 datasource - 2nd iteration"
+  	echo "######################################################"
+  	echo
+  	curl "http://${KRUIZE_URL}/dsmetadata?datasource=${DATASOURCE}&verbose=true"
+  	echo
 
-  echo
-  echo "######################################################"
-  echo "#     Display metadata for default namespace - 2nd iteration"
-  echo "######################################################"
-  echo
-  curl "http://${KRUIZE_URL}/dsmetadata?datasource=${DATASOURCE}&cluster_name=${CLUSTER_NAME}&namespace=${NAMESPACE}&verbose=true"
-  echo
+  	echo
+  	echo "######################################################"
+  	echo "#     Display metadata for default namespace - 2nd iteration"
+  	echo "######################################################"
+  	echo
+  	curl "http://${KRUIZE_URL}/dsmetadata?datasource=${DATASOURCE}&cluster_name=${CLUSTER_NAME}&namespace=${NAMESPACE}&verbose=true"
+  	echo
 
-  echo
-  echo "######################################################"
-  echo "#     Multiple Import Metadata from prometheus-1 datasource"
-  echo "######################################################"
-  echo
-  create_namespace_and_install_benchmarks
-  sleep 35
-  get_urls "test-multiple-import"
-  apply_benchmark_load "test-multiple-import"
-  curl --location http://"${KRUIZE_URL}"/dsmetadata \
-  --header 'Content-Type: application/json' \
-  --data '{
-     "version": "v1.0",
-     "datasource_name": "prometheus-1"
-  }'
+  	echo
+  	echo "######################################################"
+  	echo "#     Multiple Import Metadata from prometheus-1 datasource"
+  	echo "######################################################"
+  	echo
+  	create_namespace_and_install_benchmarks
+  	sleep 35
+  	get_urls "test-multiple-import"
+  	apply_benchmark_load "test-multiple-import"
+  	curl --location http://"${KRUIZE_URL}"/dsmetadata \
+  	--header 'Content-Type: application/json' \
+  	--data '{
+     	   "version": "v1.0",
+           "datasource_name": "prometheus-1"
+  	}'
 
-  echo
-  echo "######################################################"
-  echo "#     Display metadata from prometheus-1 datasource"
-  echo "######################################################"
-  echo
-  curl "http://${KRUIZE_URL}/dsmetadata?datasource=${DATASOURCE}&verbose=true"
-  echo
+       	echo
+  	echo "######################################################"
+  	echo "#     Display metadata from prometheus-1 datasource"
+  	echo "######################################################"
+  	echo
+  	curl "http://${KRUIZE_URL}/dsmetadata?datasource=${DATASOURCE}&verbose=true"
+  	echo
 
-  echo
-  echo "######################################################"
-  echo "#     Display metadata for test-multiple-import namespace"
-  echo "######################################################"
-  echo
-  curl "http://${KRUIZE_URL}/dsmetadata?datasource=${DATASOURCE}&cluster_name=${CLUSTER_NAME}&namespace=test-multiple-import&verbose=true"
-  echo
+  	echo
+  	echo "######################################################"
+  	echo "#     Display metadata for test-multiple-import namespace"
+  	echo "######################################################"
+  	echo
+  	curl "http://${KRUIZE_URL}/dsmetadata?datasource=${DATASOURCE}&cluster_name=${CLUSTER_NAME}&namespace=test-multiple-import&verbose=true"
+  	echo
 
-  echo
-  echo "######################################################"
-  echo "#     Delete previously created experiment"
-  echo "######################################################"
-  echo
-  echo "curl -X DELETE http://${KRUIZE_URL}/createExperiment -d @./create_tfb_exp_multiple_import.json"
-  curl -X DELETE http://${KRUIZE_URL}/createExperiment -d @./create_tfb_exp_multiple_import.json
-  echo "curl -X DELETE http://${KRUIZE_URL}/createExperiment -d @./create_tfb-db_exp_multiple_import.json"
-  curl -X DELETE http://${KRUIZE_URL}/createExperiment -d @./create_tfb-db_exp_multiple_import.json
-  echo
+  	echo
+  	echo "######################################################"
+  	echo "#     Delete previously created experiment"
+  	echo "######################################################"
+  	echo
+  	echo "curl -X DELETE http://${KRUIZE_URL}/createExperiment -d @./create_tfb_exp_multiple_import.json"
+  	curl -X DELETE http://${KRUIZE_URL}/createExperiment -d @./create_tfb_exp_multiple_import.json
+  	echo "curl -X DELETE http://${KRUIZE_URL}/createExperiment -d @./create_tfb-db_exp_multiple_import.json"
+  	curl -X DELETE http://${KRUIZE_URL}/createExperiment -d @./create_tfb-db_exp_multiple_import.json
+  	echo
 
-  echo
-  echo "######################################################"
-  echo "#     Create kruize experiment"
-  echo "######################################################"
-  echo
-  echo "curl -X POST http://${KRUIZE_URL}/createExperiment -d @./create_tfb_exp_multiple_import.json"
-  curl -X POST http://${KRUIZE_URL}/createExperiment -d @./create_tfb_exp_multiple_import.json
-  echo "curl -X POST http://${KRUIZE_URL}/createExperiment -d @./create_tfb-db_exp_multiple_import.json"
-  curl -X POST http://${KRUIZE_URL}/createExperiment -d @./create_tfb-db_exp_multiple_import.json
-  echo
+  	echo
+  	echo "######################################################"
+  	echo "#     Create kruize experiment"
+  	echo "######################################################"
+  	echo
+  	echo "curl -X POST http://${KRUIZE_URL}/createExperiment -d @./create_tfb_exp_multiple_import.json"
+  	curl -X POST http://${KRUIZE_URL}/createExperiment -d @./create_tfb_exp_multiple_import.json
+  	echo "curl -X POST http://${KRUIZE_URL}/createExperiment -d @./create_tfb-db_exp_multiple_import.json"
+  	curl -X POST http://${KRUIZE_URL}/createExperiment -d @./create_tfb-db_exp_multiple_import.json
+  	echo
 
-  echo
-  echo "######################################################"
-  echo "#     Generate recommendations"
-  echo "######################################################"
-  echo
-  curl -X POST "http://${KRUIZE_URL}/generateRecommendations?experiment_name=monitor_tfb_benchmark_multiple_import"
-  curl -X POST "http://${KRUIZE_URL}/generateRecommendations?experiment_name=monitor_tfb-db_benchmark_multiple_import"
-  echo ""
+  	echo
+  	echo "######################################################"
+  	echo "#     Generate recommendations"
+  	echo "######################################################"
+  	echo
+  	curl -X POST "http://${KRUIZE_URL}/generateRecommendations?experiment_name=monitor_tfb_benchmark_multiple_import"
+  	curl -X POST "http://${KRUIZE_URL}/generateRecommendations?experiment_name=monitor_tfb-db_benchmark_multiple_import"
+  	echo ""
 
-  echo
-  echo "######################################################"
-  echo
-  echo "Generate fresh recommendations using"
-  echo "curl -X POST http://${KRUIZE_URL}/generateRecommendations?experiment_name=monitor_tfb_benchmark_multiple_import"
-  echo
-  echo "List Recommendations using "
-  echo "curl http://${KRUIZE_URL}/listRecommendations?experiment_name=monitor_tfb_benchmark_multiple_import"
-  echo
-  echo "######################################################"
-  echo
+  	echo
+  	echo "######################################################"
+  	echo
+  	echo "Generate fresh recommendations using"
+  	echo "curl -X POST http://${KRUIZE_URL}/generateRecommendations?experiment_name=monitor_tfb_benchmark_multiple_import"
+  	echo
+  	echo "List Recommendations using "
+  	echo "curl http://${KRUIZE_URL}/listRecommendations?experiment_name=monitor_tfb_benchmark_multiple_import"
+  	echo
+  	echo "######################################################"
+  	echo
 }
 
 
@@ -273,15 +273,15 @@ function kruize_local() {
 #  Get URLs
 ###########################################
 function get_urls() {
-  local namespace="${1:-$NAMESPACE}"
-  local kubectl_cmd
+  	local namespace="${1:-$NAMESPACE}"
+  	local kubectl_cmd
 
-  if [ -n "$namespace" ]; then
-    kubectl_cmd="kubectl -n $namespace"
-  else
-	  kubectl_cmd="kubectl -n default"
+  	if [ -n "$namespace" ]; then
+    		kubectl_cmd="kubectl -n $namespace"
+  	else
+		kubectl_cmd="kubectl -n default"
 	fi
-  echo "Using namespace: ${kubectl_cmd}"
+
 	TECHEMPOWER_PORT=$(${kubectl_cmd} get svc tfb-qrh-service --no-headers -o=custom-columns=PORT:.spec.ports[*].nodePort)
 	TECHEMPOWER_IP=$(${kubectl_cmd} get pods -l=app=tfb-qrh-deployment -o wide -o=custom-columns=NODE:.spec.nodeName --no-headers)
 

--- a/monitoring/local_monitoring/local_monitoring_demo.sh
+++ b/monitoring/local_monitoring/local_monitoring_demo.sh
@@ -156,17 +156,17 @@ function kruize_local() {
   	echo
 
   	echo
-  	echo "######################################################"
+  	echo "######################################################################"
   	echo "#     Display metadata from prometheus-1 datasource - 2nd iteration"
-  	echo "######################################################"
+  	echo "######################################################################"
   	echo
   	curl "http://${KRUIZE_URL}/dsmetadata?datasource=${DATASOURCE}&verbose=true"
   	echo
 
   	echo
-  	echo "######################################################"
+  	echo "#####################################################################"
   	echo "#     Import metadata from prometheus-1 datasource - 2nd iteration"
-  	echo "######################################################"
+  	echo "#####################################################################"
   	echo
   	curl --location http://"${KRUIZE_URL}"/dsmetadata \
   	--header 'Content-Type: application/json' \
@@ -177,27 +177,28 @@ function kruize_local() {
 
 
   	echo
-  	echo "######################################################"
+  	echo "######################################################################"
   	echo "#     Display metadata from prometheus-1 datasource - 2nd iteration"
-  	echo "######################################################"
+  	echo "######################################################################"
   	echo
   	curl "http://${KRUIZE_URL}/dsmetadata?datasource=${DATASOURCE}&verbose=true"
   	echo
 
   	echo
-  	echo "######################################################"
+  	echo "###############################################################"
   	echo "#     Display metadata for default namespace - 2nd iteration"
-  	echo "######################################################"
+  	echo "###############################################################"
   	echo
   	curl "http://${KRUIZE_URL}/dsmetadata?datasource=${DATASOURCE}&cluster_name=${CLUSTER_NAME}&namespace=${NAMESPACE}&verbose=true"
   	echo
 
   	echo
-  	echo "######################################################"
+  	echo "##############################################################"
   	echo "#     Multiple Import Metadata from prometheus-1 datasource"
-  	echo "######################################################"
+  	echo "##############################################################"
   	echo
-  	create_namespace_and_install_benchmarks
+  	create_namespace
+  	benchmarks_install "test-multiple-import"
   	sleep 35
   	get_urls "test-multiple-import"
   	apply_benchmark_load "test-multiple-import"
@@ -217,9 +218,9 @@ function kruize_local() {
   	echo
 
   	echo
-  	echo "######################################################"
+  	echo "############################################################"
   	echo "#     Display metadata for test-multiple-import namespace"
-  	echo "######################################################"
+  	echo "############################################################"
   	echo
   	curl "http://${KRUIZE_URL}/dsmetadata?datasource=${DATASOURCE}&cluster_name=${CLUSTER_NAME}&namespace=test-multiple-import&verbose=true"
   	echo

--- a/monitoring/local_monitoring/local_monitoring_demo.sh
+++ b/monitoring/local_monitoring/local_monitoring_demo.sh
@@ -157,6 +157,14 @@ function kruize_local() {
 
   echo
   echo "######################################################"
+  echo "#     Display metadata from prometheus-1 datasource - 2nd iteration"
+  echo "######################################################"
+  echo
+  curl "http://${KRUIZE_URL}/dsmetadata?datasource=${DATASOURCE}&verbose=true"
+  echo
+
+  echo
+  echo "######################################################"
   echo "#     Import metadata from prometheus-1 datasource - 2nd iteration"
   echo "######################################################"
   echo

--- a/monitoring/local_monitoring/local_monitoring_demo.sh
+++ b/monitoring/local_monitoring/local_monitoring_demo.sh
@@ -141,6 +141,80 @@ function kruize_local() {
 	echo
 	echo "######################################################"
 	echo
+
+	echo
+  echo "######################################################"
+  echo "#     Delete previously imported metadata"
+  echo "######################################################"
+  echo
+  curl -X DELETE http://"${KRUIZE_URL}"/dsmetadata \
+  	--header 'Content-Type: application/json' \
+  	--data '{
+  	   "version": "v1.0",
+  	   "datasource_name": "prometheus-1"
+  	}'
+  echo
+
+  echo
+  echo "######################################################"
+  echo "#     Import metadata from prometheus-1 datasource - 2nd iteration"
+  echo "######################################################"
+  echo
+  curl --location http://"${KRUIZE_URL}"/dsmetadata \
+  --header 'Content-Type: application/json' \
+  --data '{
+     "version": "v1.0",
+     "datasource_name": "prometheus-1"
+  }'
+
+
+  echo
+  echo "######################################################"
+  echo "#     Display metadata from prometheus-1 datasource - 2nd iteration"
+  echo "######################################################"
+  echo
+  curl "http://${KRUIZE_URL}/dsmetadata?datasource=${DATASOURCE}&verbose=true"
+  echo
+
+  echo
+  echo "######################################################"
+  echo "#     Display metadata for default namespace - 2nd iteration"
+  echo "######################################################"
+  echo
+  curl "http://${KRUIZE_URL}/dsmetadata?datasource=${DATASOURCE}&cluster_name=${CLUSTER_NAME}&namespace=${NAMESPACE}&verbose=true"
+  echo
+
+  echo
+  echo "######################################################"
+  echo "#     Create kruize experiment - 2nd iteration"
+  echo "######################################################"
+  echo
+  echo "curl -X POST http://${KRUIZE_URL}/createExperiment -d @./create_tfb_exp_multiple_import.json"
+  curl -X POST http://${KRUIZE_URL}/createExperiment -d @./create_tfb_exp_multiple_import.json
+  echo "curl -X POST http://${KRUIZE_URL}/createExperiment -d @./create_tfb-db_exp_multiple_import.json"
+  curl -X POST http://${KRUIZE_URL}/createExperiment -d @./create_tfb-db_exp_multiple_import.json
+  echo
+
+  echo
+  echo "######################################################"
+  echo "#     Generate recommendations - 2nd iteration"
+  echo "######################################################"
+  echo
+  curl -X POST "http://${KRUIZE_URL}/generateRecommendations?experiment_name=monitor_tfb_benchmark_multiple_import"
+  curl -X POST "http://${KRUIZE_URL}/generateRecommendations?experiment_name=monitor_tfb-db_benchmark_multiple_import"
+  echo ""
+
+  echo
+  echo "######################################################"
+  echo
+  echo "Generate fresh recommendations - 2nd iteration using"
+  echo "curl -X POST http://${KRUIZE_URL}/generateRecommendations?experiment_name=monitor_tfb_benchmark_multiple_import"
+  echo
+  echo "List Recommendations using "
+  echo "curl http://${KRUIZE_URL}/listRecommendations?experiment_name=monitor_tfb_benchmark_multiple_import"
+  echo
+  echo "######################################################"
+  echo
 }
 
 


### PR DESCRIPTION
## Description

This PR updates local monitoring demo script showcasing multiple metadata import actions adding below steps:

- Delete previously imported metadata
- List Metadata to ensure metadata database records are deleted successfully
- Import metadata from prometheus-1 datasource 
- Display metadata from prometheus-1 datasource 
- Create new namespace and deploy an app in new namespace created
- Multiple import metadata action in the same prometheus-1 datasource
- Display metadata from prometheus-1 datasource 
- Create kruize experiments - for the new containers with different experiment names
- Generate recommendations for the new experiments created

Local monitoring demo execution on `minikube`: https://privatebin.corp.redhat.com/?efc4bba2780cb09d#5NrFVVVx3ksogT2WJaXjP1QtMMH1S2mZPQbrZu4b5EeL

on `Openshift`: https://privatebin.corp.redhat.com/?11f2190fd5439274#CC2qpvigvJPAF2F3HEnUpH6frAKDmBmrwTED9dRfhmPc

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Enhancement


## How has this been tested?
**Test Configuration**
* Kubernetes clusters tested on: minikube and openshift

## Checklist :dart:

- [x] Followed coding guidelines
- [x] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [x] Tests added or updated

## Additional information

Docker image : ` quay.io/shbirada/multiple_import:kl`