### PR TITLE
Delete namespace in local demo termination

### DIFF
--- a/common/common_helper.sh
+++ b/common/common_helper.sh
@@ -373,3 +373,21 @@ function check_kind() {
 		exit 1
 	fi
 }
+
+###########################################
+#   Delete namespace
+###########################################
+function delete_namespace() {
+  DAPP_NAMESPACE=$1
+  echo
+  echo "#########################################"
+  # Check if the namespace exists
+    if kubectl get namespace "${DAPP_NAMESPACE}" > /dev/null 2>&1; then
+      echo "Deleting namespace: ${DAPP_NAMESPACE}"
+      kubectl delete namespace "${DAPP_NAMESPACE}"
+    else
+      echo "Namespace '${DAPP_NAMESPACE}' does not exist."
+    fi
+  echo "#########################################"
+  echo
+}

--- a/monitoring/local_monitoring/local_monitoring_demo.sh
+++ b/monitoring/local_monitoring/local_monitoring_demo.sh
@@ -491,6 +491,7 @@ function kruize_local_demo_terminate() {
 		kruize_uninstall
 	fi
 	delete_repos autotune
+	delete_namespace "test-multiple-import"
 	end_time=$(get_date)
 	elapsed_time=$(time_diff "${start_time}" "${end_time}")
 	echo "Success! Kruize demo cleanup took ${elapsed_time} seconds"


### PR DESCRIPTION
This PR adds a `delete_namespace` function and deletes `test-multiple-import` namespace during local monitoring demo script termination.