### PR TITLE
Disable local monitoring for remote monitoring recommendation validation

### DIFF
--- a/common/common_helper.sh
+++ b/common/common_helper.sh
@@ -780,3 +780,11 @@ function kruize_local_demo_terminate() {
 	echo
 }
 
+function kruize_local_disable() {
+        if [ ${CLUSTER_TYPE} == "minikube" ]; then
+                sed -i 's/"local": "true"/"local": "false"/' manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
+        elif [ ${CLUSTER_TYPE} == "openshift" ]; then
+                sed -i 's/"local": "true"/"local": "false"/' manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+        fi
+}
+

--- a/monitoring/remote_monitoring_demo/recommendations_infra_demo/recommendations_demo.sh
+++ b/monitoring/remote_monitoring_demo/recommendations_infra_demo/recommendations_demo.sh
@@ -82,14 +82,7 @@ function kruize_install() {
 	pushd autotune >/dev/null
 		# Checkout the mvp_demo branch for now
 		git checkout mvp_demo
-
-		# Set local monitoring to false
-                if [ ${CLUSTER_TYPE} == "minikube" ]; then
-                        sed -i 's/"local": "true"/"local": "false"/' manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
-                elif [ ${CLUSTER_TYPE} == "openshift" ]; then
-                        sed -i 's/"local": "true"/"local": "false"/' manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
-                fi
-
+		kruize_local_disable
 
 		AUTOTUNE_VERSION="$(grep -A 1 "autotune" pom.xml | grep version | awk -F '>' '{ split($2, a, "<"); print a[1] }')"
 

--- a/monitoring/remote_monitoring_demo/recommendations_infra_demo/recommendations_demo.sh
+++ b/monitoring/remote_monitoring_demo/recommendations_infra_demo/recommendations_demo.sh
@@ -83,6 +83,14 @@ function kruize_install() {
 		# Checkout the mvp_demo branch for now
 		git checkout mvp_demo
 
+		# Set local monitoring to false
+                if [ ${CLUSTER_TYPE} == "minikube" ]; then
+                        sed -i 's/"local": "true"/"local": "false"/' manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
+                elif [ ${CLUSTER_TYPE} == "openshift" ]; then
+                        sed -i 's/"local": "true"/"local": "false"/' manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+                fi
+
+
 		AUTOTUNE_VERSION="$(grep -A 1 "autotune" pom.xml | grep version | awk -F '>' '{ split($2, a, "<"); print a[1] }')"
 
 		echo "Terminating existing installation of kruize with  ./deploy.sh -c ${CLUSTER_TYPE} -m ${target} -t"

--- a/monitoring/remote_monitoring_demo/recommendations_infra_demo/requirements.txt
+++ b/monitoring/remote_monitoring_demo/recommendations_infra_demo/requirements.txt
@@ -2,3 +2,4 @@ requests
 jsonschema
 typer
 pandas==1.1.5
+numpy==1.19.5

--- a/monitoring/remote_monitoring_demo/remote_monitoring_demo.sh
+++ b/monitoring/remote_monitoring_demo/remote_monitoring_demo.sh
@@ -83,6 +83,7 @@ function kruize_install() {
 	pushd autotune >/dev/null
 		# Checkout mvp_demo to get the latest mvp_demo release version
 		git checkout mvp_demo >/dev/null 2>/dev/null
+		kruize_local_disable
 
 		AUTOTUNE_VERSION="$(grep -A 1 "autotune" pom.xml | grep version | awk -F '>' '{ split($2, a, "<"); print a[1] }')"
 		# Kruize UI repo


### PR DESCRIPTION
Disable local monitoring for remote monitoring recommendation validation by setting local to false in manifests.