### PR TITLE
Use  mvp_demo branch of kruize to run the demos

### DIFF
--- a/common/common_helper.sh
+++ b/common/common_helper.sh
@@ -146,6 +146,8 @@ function kruize_install() {
 	fi
 	pushd autotune >/dev/null
 		{
+		# Chekout mvp_demo
+		git checkout mvp_demo >/dev/null 2>/dev/null
 		KRUIZE_VERSION="$(grep -A 1 "autotune" pom.xml | grep version | awk -F '>' '{ split($2, a, "<"); print a[1] }')"
 		# Kruize UI repo
 		KRUIZE_UI_REPO="quay.io/kruize/kruize-ui"

--- a/monitoring/local_monitoring/common.sh
+++ b/monitoring/local_monitoring/common.sh
@@ -294,7 +294,7 @@ function kruize_local_demo_setup() {
 		fi
 	} >> "${LOG_FILE}" 2>&1
 	echo "✅ Done!"
-	if [ ${env_setup} -eq 1 ]; then
+	if [[ ${env_setup} -eq 1 ]]; then
 		if [ ${CLUSTER_TYPE} == "minikube" ]; then
 			echo -n "🔄 Installing minikube and prometheus! Please wait..."
 			sys_cpu_mem_check
@@ -313,7 +313,7 @@ function kruize_local_demo_setup() {
 			prometheus_install
 			echo "✅ Installation of kind and prometheus complete!"
 		fi
-	elif [ ${env_setup} -eq 0 ]; then
+	elif [[ ${env_setup} -eq 0 ]]; then
 		if [ ${CLUSTER_TYPE} == "minikube" ]; then
 			echo -n "🔄 Checking if minikube exists..."
 			check_minikube
@@ -368,6 +368,7 @@ function kruize_local_demo_setup() {
 
 	if [ ${demo} == "local" ]; then
 		echo -n "🔄 Installing metric profile..."
+		sleep 40
 		kruize_local_metric_profile
 		echo "✅ Installation of metric profile complete!"
 		echo -n "🔄 Collecting metadata..."

--- a/monitoring/local_monitoring/common.sh
+++ b/monitoring/local_monitoring/common.sh
@@ -368,7 +368,6 @@ function kruize_local_demo_setup() {
 
 	if [ ${demo} == "local" ]; then
 		echo -n "🔄 Installing metric profile..."
-		sleep 40
 		kruize_local_metric_profile
 		echo "✅ Installation of metric profile complete!"
 		echo -n "🔄 Collecting metadata..."


### PR DESCRIPTION
Description:
Changes to the manifests are not merged into the main repository until the release. To use the kruize-demos during testing, it is necessary to check out the mvp_demo branch.

Previously, certain changes were commented out because they were part of kruize_local_patch, which is no longer required since localmonitoring is now the default.

This update includes the checkout of the mvp_demo branch as part of the Kruize installation process.
