### PR TITLE
Add MetadataProfile PoC demo

### DIFF
--- a/monitoring/local_monitoring/experiments/experiment_template.json
+++ b/monitoring/local_monitoring/experiments/experiment_template.json
@@ -3,6 +3,7 @@
   "experiment_name": "monitor_container_PLACEHOLDER_CONTAINER",
   "cluster_name": "default",
   "performance_profile": "resource-optimization-local-monitoring",
+  "metadata_profile": "cluster-metadata-local-monitoring",
   "mode": "monitor",
   "target_cluster": "local",
   "datasource": "prometheus-1",

--- a/monitoring/local_monitoring/experiments/namespace_experiment_template.json
+++ b/monitoring/local_monitoring/experiments/namespace_experiment_template.json
@@ -3,6 +3,7 @@
   "experiment_name": "monitor_namespace_PLACEHOLDER_NAMESPACE_NAME",
   "cluster_name": "default",
   "performance_profile": "resource-optimization-local-monitoring",
+  "metadata_profile": "cluster-metadata-local-monitoring",
   "mode": "monitor",
   "target_cluster": "local",
   "datasource": "prometheus-1",


### PR DESCRIPTION
This PR includes metadata profile changes in the existing local monitoring demo
Docker image - `quay.io/shbirada/metadata_profile:poc`

NOTE - add [manifests/autotune/metadata-profiles/cluster-metadata-local-monitoring.json](https://github.com/kruize/autotune/pull/1402/files#diff-40203025284530c09222e75dcb6f0f7d3ace060273b4660861d56027f1186950) once Kruize is installed.