### PR TITLE
Update resource configuration for recommendation validation demo

### DIFF
--- a/common/common_helper.sh
+++ b/common/common_helper.sh
@@ -800,3 +800,17 @@ function kruize_local_disable() {
 	fi
 }
 
+#
+# Restores kruize default cpu/memory resources, PV storage for openshift
+#
+function kruize_remote_demo_patch() {
+	CRC_DIR="./manifests/crc/default-db-included-installation"
+	KRUIZE_CRC_DEPLOY_MANIFEST_OPENSHIFT="${CRC_DIR}/openshift/kruize-crc-openshift.yaml"
+
+
+  if [ ${cluster_type} == "openshift" ]; then
+    sed -i 's/\([[:space:]]*\)\(storage:\)[[:space:]]*[0-9]\+Mi/\1\2 1Gi/' ${KRUIZE_CRC_DEPLOY_MANIFEST_OPENSHIFT}
+    sed -i 's/\([[:space:]]*\)\(memory:\)[[:space:]]*".*"/\1\2 "2Gi"/; s/\([[:space:]]*\)\(cpu:\)[[:space:]]*".*"/\1\2 "2"/' ${KRUIZE_CRC_DEPLOY_MANIFEST_OPENSHIFT}
+  fi
+}
+

--- a/monitoring/remote_monitoring_demo/recommendations_infra_demo/recommendations_demo.sh
+++ b/monitoring/remote_monitoring_demo/recommendations_infra_demo/recommendations_demo.sh
@@ -174,6 +174,7 @@ function monitoring_demo_start() {
 
 	if [[ ${demo_monitoring_setup} -eq 1 ]]; then
 		clone_repos autotune
+		kruize_remote_demo_patch
 		monitoring_demo_setup
 	fi
 


### PR DESCRIPTION
With the latest resource updates by default Kruize uses 500Mi PVC storage, 0.7 cores - 350Mi for kruize and 0.5 cores - 100Mi for kruize-db.

This PR restores the previous default values i.e 1Gi of PVC storage, 2 cores of CPU and 2Gi of memory while deploying Kruize in remote monitoring - recommendation validation demo tests for Openshift. To fix the 502 error faced for `/updateRecommendations` followed by 503 erros for subsequent API calls  faced during testing due to the resource constraints.