### PR TITLE
New bulk format Demo fix

### DIFF
--- a/common/common_helper.sh
+++ b/common/common_helper.sh
@@ -586,7 +586,7 @@ function delete_namespace_resource_quota() {
 	echo
 }
 
-# Function to check if a port is in use
+#  Function to check if a port is in use
 function is_port_in_use() {
 	local port=$1
 	if lsof -i :$port -t >/dev/null 2>&1; then

--- a/common/common_helper.sh
+++ b/common/common_helper.sh
@@ -707,6 +707,10 @@ function get_urls() {
 			export TECHEMPOWER_URL="${KIND_IP}:${TECHEMPOWER_PORT}"
 		fi
 
+  elif [ ${CLUSTER_TYPE} == "local" ]; then
+    export KRUIZE_URL="127.0.0.1:8080"
+    export KRUIZE_UI_URL="127.0.0.1:8080"
+
 	elif [ ${CLUSTER_TYPE} == "openshift" ]; then
 		kubectl_cmd="oc -n openshift-tuning"
 		kubectl_app_cmd="oc -n ${APP_NAMESPACE}"

--- a/monitoring/local_monitoring/bulk_demo/bulk_demo.py
+++ b/monitoring/local_monitoring/bulk_demo/bulk_demo.py
@@ -100,8 +100,9 @@ def bulk_status(job_id):
         if exp_list != "":
             print("✅ Complete!")
             print(f"🔄 List the recommendations for {exp_count} experiments...", end="")
+            list_include = "experiments"
             for exp_name in exp_list:
-                response = list_recommendations(exp_name)
+                response = get_bulk_job_status(job_id, list_include, exp_name)
                 reco = response.json()
                 recommendations_json_arr.append(reco)
                 counter -= 1

--- a/monitoring/local_monitoring/bulk_demo/bulk_demo.py
+++ b/monitoring/local_monitoring/bulk_demo/bulk_demo.py
@@ -117,8 +117,8 @@ def bulk_status(job_id):
             thread_print("List of all experiments are available in experiment_list.txt")
             print("✅ Complete!")
         else:
-            thread_print("⚠️  Something went wrong! There are no experiments with recommendations!")
-            print("⚠️  Something went wrong! There are no experiments with recommendations!")
+            thread_print("⚠️ Something went wrong! There are no experiments with recommendations!")
+            print("⚠️ Something went wrong! There are no experiments with recommendations!")
         status = True
         return
     else:

--- a/monitoring/local_monitoring/bulk_demo/kruize/kruize.py
+++ b/monitoring/local_monitoring/bulk_demo/kruize/kruize.py
@@ -15,15 +15,14 @@ limitations under the License.
 """
 
 import json
-import subprocess
-
 import requests
+import subprocess
 
 
 def form_kruize_url(cluster_type, SERVER_IP=None):
     global URL
-    KIND_IP="127.0.0.1"
-    KRUIZE_PORT=8080
+    KIND_IP = "127.0.0.1"
+    KRUIZE_PORT = 8080
 
     if SERVER_IP != None:
         URL = "http://" + str(SERVER_IP)
@@ -42,16 +41,22 @@ def form_kruize_url(cluster_type, SERVER_IP=None):
         URL = "http://" + str(SERVER_IP) + ":" + str(AUTOTUNE_PORT)
     elif (cluster_type == "kind"):
         URL = "http://" + KIND_IP + ":" + str(KRUIZE_PORT)
+    elif (cluster_type == "local"):
+        URL = "http://" + '127.0.0.1' + ":" + '8080'
     elif (cluster_type == "openshift"):
 
-        subprocess.run(['oc expose svc/kruize -n openshift-tuning'], shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        subprocess.run(['oc expose svc/kruize -n openshift-tuning'], shell=True, stdout=subprocess.PIPE,
+                       stderr=subprocess.PIPE)
         ip = subprocess.run(
-            ['oc status -n openshift-tuning | grep "kruize" | grep -v "kruize-ui" | grep -v "kruize-db" | grep port | cut -d " " -f1 | cut -d "/" -f3'], shell=True,
+            [
+                'oc status -n openshift-tuning | grep "kruize" | grep -v "kruize-ui" | grep -v "kruize-db" | grep port | cut -d " " -f1 | cut -d "/" -f3'],
+            shell=True,
             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         SERVER_IP = ip.stdout.decode('utf-8').strip('\n')
         print("IP = ", SERVER_IP)
         URL = "http://" + str(SERVER_IP)
     print("\nKRUIZE URL = ", URL)
+
 
 # Description: This function creates a metric profile using the Kruize createMetricProfile API
 # Input Parameters: metric profile json
@@ -59,7 +64,7 @@ def create_metric_profile(metric_profile_json_file):
     json_file = open(metric_profile_json_file, "r")
     metric_profile_json = json.loads(json_file.read())
 
-    #print("\nCreating metric profile...")
+    # print("\nCreating metric profile...")
     url = URL + "/createMetricProfile"
     print("URL = ", url)
 
@@ -68,41 +73,44 @@ def create_metric_profile(metric_profile_json_file):
     print(response.text)
     return response
 
+
 # Description: This function invokes the Kruize bulk service API
 # Input Parameters: bulk json
 def bulk(bulk_json_file):
     json_file = open(bulk_json_file, "r")
     bulk_json = json.loads(json_file.read())
 
-    #print("\nInvoking bulk service...")
+    # print("\nInvoking bulk service...")
     url = URL + "/bulk"
     print("URL = ", url)
 
     response = requests.post(url, json=bulk_json)
     return response
 
+
 # Description: This function invokes the Kruize bulk service API
 # Input Parameters: job id returned from bulk service
-def get_bulk_job_status(job_id, verbose = None):
-    #print("\nGet the bulk job status for job id %s " % (job_id))
+def get_bulk_job_status(job_id, include=None):
+    # print("\nGet the bulk job status for job id %s " % (job_id))
     queryString = "?"
     if job_id:
         queryString = queryString + "job_id=%s" % (job_id)
-    if verbose:
-        queryString = queryString + "&verbose=%s" % (verbose)
+    if include:
+        queryString = queryString + "&include=%s" % (include)
 
     url = URL + "/bulk%s" % (queryString)
-    #print("URL = ", url)
+    # print("URL = ", url)
     response = requests.get(url, )
     return response
+
 
 # Description: This function obtains the recommendations from Kruize Autotune using listRecommendations API
 # Input Parameters: experiment name, flag indicating latest result and monitoring end time
 def list_recommendations(experiment_name=None, latest=None, monitoring_end_time=None):
     PARAMS = ""
-    #print("\nListing the recommendations...")
+    # print("\nListing the recommendations...")
     url = URL + "/listRecommendations"
-    #print("URL = ", url)
+    # print("URL = ", url)
 
     if experiment_name == None:
         if latest == None and monitoring_end_time == None:
@@ -119,14 +127,15 @@ def list_recommendations(experiment_name=None, latest=None, monitoring_end_time=
         elif monitoring_end_time != None:
             PARAMS = {'experiment_name': experiment_name, 'monitoring_end_time': monitoring_end_time}
 
-    #print("PARAMS = ", PARAMS)
+    # print("PARAMS = ", PARAMS)
     response = requests.get(url=url, params=PARAMS)
 
-    #print("Response status code = ", response.status_code)
-    #print("\n************************************************************")
-    #print(response.text)
-    #print("\n************************************************************")
+    # print("Response status code = ", response.status_code)
+    # print("\n************************************************************")
+    # print(response.text)
+    # print("\n************************************************************")
     return response
+
 
 # Description: This function validates the input json and posts the experiment using createExperiment API to Kruize Autotune
 # Input Parameters: experiment input json
@@ -193,6 +202,7 @@ def update_recommendations(experiment_name, startTime, endTime):
     print("\n************************************************************")
     return response
 
+
 # Description: This function deletes the experiment and posts the experiment using createExperiment API to Kruize Autotune
 # Input Parameters: experiment input json
 def delete_experiment(input_json_file, invalid_header=False):
@@ -219,6 +229,7 @@ def delete_experiment(input_json_file, invalid_header=False):
     print(response)
     print("Response status code = ", response.status_code)
     return response
+
 
 # Description: This function obtains the experiments from Kruize Autotune using listExperiments API
 # Input Parameters: None
@@ -369,6 +380,7 @@ def list_metadata(datasource=None, cluster_name=None, namespace=None, verbose=No
         print(response.text)
         print("\n************************************************************")
     return response
+
 
 # Description: This function deletes the metric profile
 # Input Parameters: metric profile input json

--- a/monitoring/local_monitoring/bulk_demo/kruize/kruize.py
+++ b/monitoring/local_monitoring/bulk_demo/kruize/kruize.py
@@ -90,13 +90,15 @@ def bulk(bulk_json_file):
 
 # Description: This function invokes the Kruize bulk service API
 # Input Parameters: job id returned from bulk service
-def get_bulk_job_status(job_id, include=None):
+def get_bulk_job_status(job_id, include=None, experimentName=None):
     # print("\nGet the bulk job status for job id %s " % (job_id))
     queryString = "?"
     if job_id:
-        queryString = queryString + "job_id=%s" % (job_id)
+        queryString = queryString + "job_id=%s&" % (job_id)
+    if experimentName:
+        queryString = queryString + "experiment_name=%s&" % (experimentName)
     if include:
-        queryString = queryString + "&include=%s" % (include)
+        queryString = queryString + "include=%s" % (include)
 
     url = URL + "/bulk%s" % (queryString)
     response = requests.get(url, )

--- a/monitoring/local_monitoring/bulk_demo/kruize/kruize.py
+++ b/monitoring/local_monitoring/bulk_demo/kruize/kruize.py
@@ -99,7 +99,6 @@ def get_bulk_job_status(job_id, include=None):
         queryString = queryString + "&include=%s" % (include)
 
     url = URL + "/bulk%s" % (queryString)
-    # print("URL = ", url)
     response = requests.get(url, )
     return response
 

--- a/monitoring/local_monitoring/common.sh
+++ b/monitoring/local_monitoring/common.sh
@@ -402,7 +402,9 @@ function kruize_local_demo_setup() {
 
 	echo -n "🔄 Installing kruize! Please wait..."
 	kruize_start_time=$(get_date)
-	kruize_install &
+	if [ ${CLUSTER_TYPE} != "local" ]; then
+	  kruize_install &
+	fi
 	install_pid=$!
 	while kill -0 $install_pid 2>/dev/null;
  	do

--- a/monitoring/local_monitoring/common.sh
+++ b/monitoring/local_monitoring/common.sh
@@ -30,9 +30,9 @@ function kruize_local_metric_profile() {
 	fi
 	{
 		echo
-		echo "######################################################"
+		echo "#####################################################"
 		echo "#     Install default metric profile"
-		echo "######################################################"
+		echo "#####################################################"
 		echo
 		output=$(curl -X POST http://${KRUIZE_URL}/createMetricProfile -d @$resource_optimization_local_monitoring)
 		echo


### PR DESCRIPTION
```
[vinakuma@vinakuma-thinkpadp1gen3 bulk_demo]$ ./bulk_service_demo.sh -c openshift -i quay.io/vinakuma/autotune_operator:shk4

#######################################
# Kruize Demo Setup on openshift 
#######################################

🔄 Pulling required repositories... ✅ Done!
🔄 Installing kruize! Please wait.....................✅ Installation of kruize complete!
🔄 Installing metric profile...✅ Installation of metric profile complete!
🔄 Invoking bulk service...✅ Invoked job_id 669fe19c-0c71-400d-9098-77d2725f27d2
🔔 Bulk job experiment details are currently being updated in ./kruize-bulk-demo.log.
🔄 Processing 138 experiments. Please wait.....✅ Complete!
🔄 Fetching the experiments...✅ Complete!
🔄 List the recommendations for 1 experiments....✅ Complete!
📌 List of all experiments available in experiment_list.txt
📌 Recommendations for a single container in cluster can be found in recommendations_data.json.
📌 Job status is available in job_status.json


ℹ️  Access kruize UI at http://kruize-ui-nginx-service-openshift-tuning.apps.kruize.lab.psi.pnq2.redhat.com
🔖 To explore further, access kruize UI to list and create experiments, and to view or generate recommendations!
ℹ️  For kruize CLI commands, refer to the end of ./kruize-bulk-demo.log

🛠️ Kruize installation took 91 seconds
🚀 Kruize experiment creation and recommendations generation took 133 seconds
🕒 Success! Kruize demo setup took 226 seconds

For detailed logs, look in kruize-bulk-demo.log
```




Logs attached
[kruize-bulk-demo.log](https://github.com/user-attachments/files/18573004/kruize-bulk-demo.log)
[job_status.json](https://github.com/user-attachments/files/18573007/job_status.json)
