### PR TITLE
[Demos] Include metadata_profile field in local monitoring demos

### DIFF
--- a/monitoring/local_monitoring/bulk_demo/bulk_input.json
+++ b/monitoring/local_monitoring/bulk_demo/bulk_input.json
@@ -13,7 +13,8 @@
       "labels": {}
     }
   },
-
+  "metadata_profile": "cluster-metadata-local-monitoring",
+  "measurement_duration": "15mins",
   "time_range": {
 	"start": null,
 	"end": null

--- a/monitoring/local_monitoring/experiments/container_experiment_sysbench.json
+++ b/monitoring/local_monitoring/experiments/container_experiment_sysbench.json
@@ -3,6 +3,7 @@
   "experiment_name": "monitor_sysbench",
   "cluster_name": "default",
   "performance_profile": "resource-optimization-local-monitoring",
+  "metadata_profile": "cluster-metadata-local-monitoring",
   "mode": "monitor",
   "target_cluster": "local",
   "datasource": "prometheus-1",

--- a/monitoring/local_monitoring/experiments/create_human_eval_exp.json
+++ b/monitoring/local_monitoring/experiments/create_human_eval_exp.json
@@ -3,6 +3,7 @@
   "experiment_name": "monitor_human_eval_benchmark",
   "cluster_name": "default",
   "performance_profile": "resource-optimization-local-monitoring",
+  "metadata_profile": "cluster-metadata-local-monitoring",
   "mode": "monitor",
   "target_cluster": "local",
   "datasource": "prometheus-1",

--- a/monitoring/local_monitoring/experiments/create_llm_rag_exp.json
+++ b/monitoring/local_monitoring/experiments/create_llm_rag_exp.json
@@ -3,6 +3,7 @@
   "experiment_name": "monitor_llm_rag_benchmark",
   "cluster_name": "default",
   "performance_profile": "resource-optimization-local-monitoring",
+  "metadata_profile": "cluster-metadata-local-monitoring",
   "mode": "monitor",
   "target_cluster": "local",
   "datasource": "prometheus-1",

--- a/monitoring/local_monitoring/experiments/create_namespace_exp.json
+++ b/monitoring/local_monitoring/experiments/create_namespace_exp.json
@@ -3,6 +3,7 @@
     "experiment_name": "monitor_app_namespace",
     "cluster_name": "default",
     "performance_profile": "resource-optimization-local-monitoring",
+    "metadata_profile": "cluster-metadata-local-monitoring",
     "mode": "monitor",
     "target_cluster": "local",
     "datasource": "prometheus-1",

--- a/monitoring/local_monitoring/experiments/create_tfb-db_exp.json
+++ b/monitoring/local_monitoring/experiments/create_tfb-db_exp.json
@@ -3,6 +3,7 @@
   "experiment_name": "monitor_tfb-db_benchmark",
   "cluster_name": "default",
   "performance_profile": "resource-optimization-local-monitoring",
+  "metadata_profile": "cluster-metadata-local-monitoring",
   "mode": "monitor",
   "target_cluster": "local",
   "datasource": "prometheus-1",

--- a/monitoring/local_monitoring/experiments/create_tfb_exp.json
+++ b/monitoring/local_monitoring/experiments/create_tfb_exp.json
@@ -3,6 +3,7 @@
   "experiment_name": "monitor_tfb_benchmark",
   "cluster_name": "default",
   "performance_profile": "resource-optimization-local-monitoring",
+  "metadata_profile": "cluster-metadata-local-monitoring",
   "mode": "monitor",
   "target_cluster": "local",
   "datasource": "prometheus-1",

--- a/monitoring/local_monitoring/experiments/create_ttm_exp.json
+++ b/monitoring/local_monitoring/experiments/create_ttm_exp.json
@@ -3,6 +3,7 @@
   "experiment_name": "monitor_ttm_benchmark",
   "cluster_name": "default",
   "performance_profile": "resource-optimization-local-monitoring",
+  "metadata_profile": "cluster-metadata-local-monitoring",
   "mode": "monitor",
   "target_cluster": "local",
   "datasource": "prometheus-1",

--- a/monitoring/local_monitoring/experiments/experiment_template.json
+++ b/monitoring/local_monitoring/experiments/experiment_template.json
@@ -3,6 +3,7 @@
   "experiment_name": "monitor_container_PLACEHOLDER_CONTAINER",
   "cluster_name": "default",
   "performance_profile": "resource-optimization-local-monitoring",
+  "metadata_profile": "cluster-metadata-local-monitoring",
   "mode": "monitor",
   "target_cluster": "local",
   "datasource": "prometheus-1",

--- a/monitoring/local_monitoring/experiments/namespace_experiment_sysbench.json
+++ b/monitoring/local_monitoring/experiments/namespace_experiment_sysbench.json
@@ -3,6 +3,7 @@
   "experiment_name": "monitor_namespace_default",
   "cluster_name": "default",
   "performance_profile": "resource-optimization-local-monitoring",
+  "metadata_profile": "cluster-metadata-local-monitoring",
   "mode": "monitor",
   "target_cluster": "local",
   "datasource": "prometheus-1",

--- a/monitoring/local_monitoring/experiments/namespace_experiment_template.json
+++ b/monitoring/local_monitoring/experiments/namespace_experiment_template.json
@@ -3,6 +3,7 @@
   "experiment_name": "monitor_namespace_PLACEHOLDER_NAMESPACE_NAME",
   "cluster_name": "default",
   "performance_profile": "resource-optimization-local-monitoring",
+  "metadata_profile": "cluster-metadata-local-monitoring",
   "mode": "monitor",
   "target_cluster": "local",
   "datasource": "prometheus-1",

--- a/monitoring/local_monitoring/gpu-demo/no-gpu/inputs/create_exp.json
+++ b/monitoring/local_monitoring/gpu-demo/no-gpu/inputs/create_exp.json
@@ -3,6 +3,7 @@
   "experiment_name": "optimize-gpu",
   "cluster_name": "default",
   "performance_profile": "resource-optimization-local-monitoring",
+  "metadata_profile": "cluster-metadata-local-monitoring",
   "mode": "recreate",
   "target_cluster": "local",
   "datasource": "prometheus-1",

--- a/monitoring/local_monitoring/vpa_demo/experiments/container_vpa_experiment_sysbench.json
+++ b/monitoring/local_monitoring/vpa_demo/experiments/container_vpa_experiment_sysbench.json
@@ -3,6 +3,7 @@
   "experiment_name": "optimize-sysbench",
   "cluster_name": "default",
   "performance_profile": "resource-optimization-local-monitoring",
+  "metadata_profile": "cluster-metadata-local-monitoring",
   "mode": "recreate",
   "target_cluster": "local",
   "datasource": "prometheus-1",


### PR DESCRIPTION
This PR has the following changes:

- Add `kruize_local_metadata_profile()` function to install metadata_profile for local monitoring
- Include `metadata_profile` and `measurement_duration` fields in bulk_input.json
- Add `kruize_local_remote_patch()` function to set `isROSEnabled=true` and mount metric and metadata profile JSONs only for bulk demo 
- Include new `metadata_profile` field in create experiment JSON files