### PR TITLE
Add option for custom instaslice image

### DIFF
--- a/monitoring/local_monitoring/gpu-demo/no-gpu/README.md
+++ b/monitoring/local_monitoring/gpu-demo/no-gpu/README.md
@@ -13,10 +13,12 @@ The script defines key environment variables needed for execution:
 - **`SAMPLE_WORKLOAD`** → The YAML file that defines the dummy GPU workload.
 - **API URLs**:
     - **`CREATE_METRICS_PROFILE`** → Endpoint to create a metrics profile in Kruize.
+    - **`CREATE_METADATA_PROFILE`** → Endpoint to create a metadata profile in Kruize.
     - **`CREATE_EXPERIMENT`** → Endpoint to create a tuning experiment in Kruize.
 - **File Paths**:
     - **`INPUT_FOLDER`** → The directory containing input JSON files.
     - **`metrics_profile_path`** → Path to the metrics profile JSON file.
+    - **`metadata_profile_path`** → Path to the metadata profile JSON file.
     - **`experiment_path`** → Path to the experiment JSON file.
 
 Additionally, the script sets up the **Go environment**:
@@ -95,9 +97,9 @@ This allows us to run GPU workloads in Kubernetes without physical GPUs.
 ---
 
 ### **9. Running Kruize for Resource Optimization**
-- The script reads **metrics profile JSON** and **experiment JSON** files.
+- The script reads **metrics and metadata profile JSON** and **experiment JSON** files.
 - It sends **POST requests** to Kruize's API:
-    - First, it **registers the metrics profile**.
+    - First, it **registers the metrics and metadata profiles**.
     - Then, it **creates an experiment** for resource tuning.
 
 ---

--- a/monitoring/local_monitoring/gpu-demo/no-gpu/inputs/metadata_profile.json
+++ b/monitoring/local_monitoring/gpu-demo/no-gpu/inputs/metadata_profile.json
@@ -1,0 +1,48 @@
+{
+  "apiVersion": "recommender.com/v1",
+  "kind": "KruizeMetadataProfile",
+  "metadata": {
+    "name": "cluster-metadata-local-monitoring"
+  },
+  "profile_version": 1,
+  "k8s_type": "openshift",
+  "datasource": "prometheus",
+  "query_variables": [
+    {
+      "name": "namespacesForAdditionalLabel",
+      "datasource": "prometheus",
+      "value_type": "double",
+      "kubernetes_object": "container",
+      "aggregation_functions": [
+        {
+          "function": "sum",
+          "query": "sum by (namespace) (avg_over_time(kube_namespace_status_phase{namespace!=\"\" ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+        }
+      ]
+    },
+    {
+      "name": "workloadsForAdditionalLabel",
+      "datasource": "prometheus",
+      "value_type": "double",
+      "kubernetes_object": "container",
+      "aggregation_functions": [
+        {
+          "function": "sum",
+          "query": "sum by (namespace, workload, workload_type) (avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!=\"\" ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+        }
+      ]
+    },
+    {
+      "name": "containersForAdditionalLabel",
+      "datasource": "prometheus",
+      "value_type": "double",
+      "kubernetes_object": "container",
+      "aggregation_functions": [
+        {
+          "function": "sum",
+          "query": "sum by (container, image, workload, workload_type, namespace) (avg_over_time(kube_pod_container_info{container!=\"\" ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]) * on (pod, namespace) group_left(workload, workload_type) avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{workload!=\"\" ADDITIONAL_LABEL}[$MEASUREMENT_DURATION_IN_MIN$m]))"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring/local_monitoring/gpu-demo/no-gpu/kruize_gpu_demo.py
+++ b/monitoring/local_monitoring/gpu-demo/no-gpu/kruize_gpu_demo.py
@@ -14,6 +14,7 @@ NODE_NAME = "kind-e2e-control-plane"
 SAMPLE_WORKLOAD = "sample_workload.yaml"
 
 CREATE_METRICS_PROFILE = f"http://127.0.0.1:8080/createMetricProfile"
+CREATE_METADATA_PROFILE = f"http://127.0.0.1:8080/createMetadataProfile"
 CREATE_EXPERIMENT = f"http://127.0.0.1:8080/createExperiment"
 
 # Input folder
@@ -21,6 +22,7 @@ INPUT_FOLDER = "inputs"
 
 # File paths
 metrics_profile_path = os.path.join(os.getcwd(), INPUT_FOLDER, "metrics_profile.json")
+metadata_profile_path = os.path.join(os.getcwd(), INPUT_FOLDER, "metadata_profile.json")
 experiment_path = os.path.join(os.getcwd(), INPUT_FOLDER, "create_exp.json")
 
 gopath = subprocess.check_output(['go', 'env', 'GOPATH'], text=True).strip()
@@ -483,6 +485,15 @@ def main():
 
     if not post_request(CREATE_METRICS_PROFILE, metrics_data, "Metric Profile"):
         print(f"✗ Error creating Metrics Profile")
+        return
+
+    metadata_profile_data = read_json(metadata_profile_path)
+    if metadata_profile_data is None:
+        print(f"✗ Error reading {metadata_profile_path}")
+        return
+
+    if not post_request(CREATE_METADATA_PROFILE, metadata_profile_data, "Metadata Profile"):
+        print(f"✗ Error creating Metadata Profile")
         return
 
     experiment_data = read_json(experiment_path)

--- a/monitoring/local_monitoring/gpu-demo/no-gpu/kruize_gpu_demo.py
+++ b/monitoring/local_monitoring/gpu-demo/no-gpu/kruize_gpu_demo.py
@@ -409,15 +409,15 @@ def main():
     parser.add_argument(
         "--insta-cntrl",
         type=str,
-        default="quay.io/bharathappali/instaslice:test-e2e-cntrl",
-        help="Image for InstaSlice controller (default: quay.io/bharathappali/instaslice:test-e2e-cntrl)"
+        default="quay.io/instaslice/instaslice:test-e2e-cntrl",
+        help="Image for InstaSlice controller (default: quay.io/instaslice/instaslice:test-e2e-cntrl)"
     )
 
     parser.add_argument(
         "--insta-dmst",
         type=str,
-        default="quay.io/bharathappali/instaslice:test-e2e-dmnst",
-        help="Image for InstaSlice daemonset (default: quay.io/bharathappali/instaslice:test-e2e-dmnst)"
+        default="quay.io/instaslice/instaslice:test-e2e-dmnst",
+        help="Image for InstaSlice daemonset (default: quay.io/instaslice/instaslice:test-e2e-dmnst)"
     )
 
     args = parser.parse_args()
@@ -428,8 +428,8 @@ def main():
     }
 
     print("Using the following image configurations:")
-    print(f"Controller Image: {env_vars['IMG']}")
-    print(f"Daemonset Image: {env_vars['IMG_DMST']}")
+    print(f"Controller Image: {env_vars['CNTRL']}")
+    print(f"Daemonset Image: {env_vars['DMST']}")
 
     instaslice_repo_url = "https://github.com/openshift/instaslice-operator.git"
     instaslice_repo_name = "instaslice-operator"


### PR DESCRIPTION
As we need to make changes in the config of instaslice we cannot use the production image (run as non root issue on local docker). So we need to create a custom image for the demo and earlier the image is loaded locally to kind but recent changes in Makefile of instaslice we now have a docker push step. So the user running this script should have a custom image pushed to repo and pulled back to kind cluster. 

So this script needs the flexibility to push own images rather than using a default image (which will have permission issues)

Fixes #130 (Thanks @shreyabiradar07 for finding this bug)

Note: This PR is built on top of PR #129 . #129 should be merged before merging this PR as this has it's changes. 