### PR TITLE
Update namespace kubernetes_object in demos

### DIFF
--- a/monitoring/local_monitoring/common.sh
+++ b/monitoring/local_monitoring/common.sh
@@ -140,8 +140,6 @@ function kruize_local_experiments() {
 	for experiment in "${EXPERIMENTS[@]}"; do
 		if [[ $experiment != "container_experiment_local" ]] || [[ $experiment != "namespace_experiment_local" ]]; then
 			sed -i 's/"namespace": "default"/"namespace": "'"${APP_NAMESPACE}"'"/' ./experiments/${experiment}.json
-			#sed -i "s/"namespace": "default"/"namespace": "${APP_NAMESPACE}"/" ./experiments/${experiment}.json
-			sed -i 's/"namespace_name": "default"/"namespace_name": "'"${APP_NAMESPACE}"'"/' ./experiments/${experiment}.json
 		fi
 	done
 
@@ -162,7 +160,7 @@ function kruize_local_experiments() {
 			curl -X POST http://${KRUIZE_URL}/createExperiment -d @./experiments/${experiment}.json
 		} >> "${LOG_FILE}" 2>&1
 		echo "✅ Created!"
-		grep -E '"experiment_name"|"container_name"|"type"|"namespace"|"namespace_name"' experiments/${experiment}.json | grep -v '"experiment_type"' | sed -E 's/.*"experiment_name": "([^"]*)".*/\tExperiment: \1/; s/.*"type": "([^"]*)".*/\tType: \1/; s/.*"container_name": "([^"]*)".*/\tContainer: \1/; s/.*"namespace": "([^"]*)".*/\tNamespace: \1/; s/.*"namespace_name": "([^"]*)".*/\tNamespace: \1/'
+		grep -E '"experiment_name"|"container_name"|"type"|"namespace"' experiments/${experiment}.json | grep -v '"experiment_type"' | sed -E 's/.*"experiment_name": "([^"]*)".*/\tExperiment: \1/; s/.*"type": "([^"]*)".*/\tType: \1/; s/.*"container_name": "([^"]*)".*/\tContainer: \1/; s/.*"namespace": "([^"]*)".*/\tNamespace: \1/;'
 	done
 
 	for experiment in "${EXPERIMENTS[@]}"; do

--- a/monitoring/local_monitoring/experiments/create_namespace_exp.json
+++ b/monitoring/local_monitoring/experiments/create_namespace_exp.json
@@ -11,7 +11,7 @@
     "kubernetes_objects": [
       {
         "namespaces": {
-          "namespace_name": "default"
+          "namespace": "default"
         }
       }
     ],

--- a/monitoring/local_monitoring/experiments/namespace_experiment_sysbench.json
+++ b/monitoring/local_monitoring/experiments/namespace_experiment_sysbench.json
@@ -11,7 +11,7 @@
   "kubernetes_objects": [
       {
         "namespaces": {
-          "namespace_name": "default"
+          "namespace": "demo-namespace"
         }
       }
     ],

--- a/monitoring/local_monitoring/experiments/namespace_experiment_sysbench.json
+++ b/monitoring/local_monitoring/experiments/namespace_experiment_sysbench.json
@@ -11,7 +11,7 @@
   "kubernetes_objects": [
       {
         "namespaces": {
-          "namespace": "demo-namespace"
+          "namespace": "default"
         }
       }
     ],

--- a/monitoring/local_monitoring/experiments/namespace_experiment_template.json
+++ b/monitoring/local_monitoring/experiments/namespace_experiment_template.json
@@ -11,7 +11,7 @@
   "kubernetes_objects": [
       {
         "namespaces": {
-          "namespace_name": "PLACEHOLDER_NAMESPACE_NAME"
+          "namespace": "PLACEHOLDER_NAMESPACE_NAME"
         }
       }
     ],


### PR DESCRIPTION
his PR includes the changes for namespace kubernetes_objects in the local monitoring demo, replacing `namespace_name` with `namespace` as the key.

Demo output on kind: [kruize-demo.log](https://github.com/user-attachments/files/20573968/kruize-demo.log)

```
./local_monitoring_demo.sh -c kind -f -i quay.io/shbirada/create_exp_changes:latest -n demo-namespace

#######################################
# Kruize Demo Setup on kind 
#######################################

🔄 Pulling required repositories... ✅ Done!
🔄 Installing kind and prometheus! Please wait...✅ Installation of kind and prometheus complete!
🔄 Installing the required benchmarks...✅ Completed!
🔄 Installing kruize! Please wait.........................................✅ Installation of kruize complete!
🔄 Installing metric profile...✅ Installation of metric profile complete!
🔄 Installing metadata profile...✅ Installation of metadata profile complete!
🔄 Collecting metadata...✅ Collection of metadata complete!
🔄 Creating container experiment: monitor_sysbench ...✅ Created!
        Experiment: monitor_sysbench
        Type: deployment
        Namespace: demo-namespace
        Container: sysbench
🔄 Creating namespace experiment: monitor_namespace_default ...✅ Created!
        Experiment: monitor_namespace_default
        Namespace: demo-namespace
🔄 Generating container recommendations for experiment: monitor_sysbench ...✅ Generated! 
🔄 Generating namespace recommendations for experiment: monitor_namespace_default ...⚠️  No recommendations generated! 

🔔 ATLEAST TWO DATAPOINTS ARE REQUIRED TO GENERATE RECOMMENDATIONS!
🔔 PLEASE WAIT FOR FEW MINS AND GENERATE THE RECOMMENDATIONS AGAIN.
🔗 Generate fresh recommendations using
curl -X POST http://127.0.0.1:8080/generateRecommendations?experiment_name=monitor_sysbench
curl -X POST http://127.0.0.1:8080/generateRecommendations?experiment_name=monitor_namespace_default

ℹ️  Access kruize UI at http://127.0.0.1:8081
🔖 To explore further, access kruize UI to list and create experiments, and to view or generate recommendations!
ℹ️  For kruize CLI commands, refer to the end of ./kruize-demo.log

🛠️ Kruize installation took 190 seconds
🚀 Kruize experiment creation and recommendations generation took 1 seconds
🕒 Success! Kruize demo setup took 349 seconds

For detailed logs, look in kruize-demo.log
```