### PR TITLE
Enable env setup by default for minikube and kind

### DIFF
--- a/monitoring/local_monitoring/bulk_demo/bulk_service_demo.sh
+++ b/monitoring/local_monitoring/bulk_demo/bulk_service_demo.sh
@@ -70,7 +70,6 @@ sys_cpu_mem_check
 export DOCKER_IMAGES=""
 export KRUIZE_DOCKER_IMAGE=""
 export prometheus=0
-export env_setup=0
 export start_demo=1
 export APP_NAMESPACE="default"
 export LOAD_DURATION="1200"
@@ -87,9 +86,6 @@ do
 			;;
 		p)
 			prometheus=1
-			;;
-		f)
-			env_setup=1
 			;;
 	  	l)
 			start_demo=2

--- a/monitoring/local_monitoring/common.sh
+++ b/monitoring/local_monitoring/common.sh
@@ -366,40 +366,24 @@ function kruize_local_demo_setup() {
 		fi
 	} >> "${LOG_FILE}" 2>&1
 	echo "✅ Done!"
-	if [[ ${env_setup} -eq 1 ]]; then
-		if [ ${CLUSTER_TYPE} == "minikube" ]; then
-			echo -n "🔄 Installing minikube and prometheus! Please wait..."
-			sys_cpu_mem_check
-			check_minikube
-			minikube >/dev/null
-			check_err "ERROR: minikube not installed"
-			minikube_start
-			prometheus_install autotune
-			echo "✅ Installation of minikube and prometheus complete!"
-		elif [ ${CLUSTER_TYPE} == "kind" ]; then
-			echo -n "🔄 Installing kind and prometheus! Please wait..."
-			check_kind
-			kind >/dev/null
-			check_err "ERROR: kind not installed"
-			kind_start
-			prometheus_install
-			echo "✅ Installation of kind and prometheus complete!"
-		fi
-	elif [[ ${env_setup} -eq 0 ]]; then
-		if [ ${CLUSTER_TYPE} == "minikube" ]; then
-			echo -n "🔄 Checking if minikube exists..."
-			check_minikube
-			minikube >/dev/null
-			check_err "ERROR: minikube is not available. Please install and try again!"
-			echo "✅ minikube exists!"
-		elif [ ${CLUSTER_TYPE} == "kind" ]; then
-			echo -n "🔄 Checking if kind exists..."
-			check_kind
-			kind >/dev/null
-			check_err "ERROR: kind is not available. Please install and try again!"
-			echo "✅ kind exists!"
-		fi
-	fi
+	if [ ${CLUSTER_TYPE} == "minikube" ]; then
+    echo -n "🔄 Installing minikube and prometheus! Please wait..."
+    sys_cpu_mem_check
+    check_minikube
+    minikube >/dev/null
+    check_err "ERROR: minikube not installed"
+    minikube_start
+    prometheus_install autotune
+    echo "✅ Installation of minikube and prometheus complete!"
+  elif [ ${CLUSTER_TYPE} == "kind" ]; then
+    echo -n "🔄 Installing kind and prometheus! Please wait..."
+    check_kind
+    kind >/dev/null
+    check_err "ERROR: kind not installed"
+    kind_start
+    prometheus_install
+    echo "✅ Installation of kind and prometheus complete!"
+  fi
 	if [ ${demo} == "local" ]; then
 		if [[ ${#EXPERIMENTS[@]} -ne 0 ]] && [[ ${EXPERIMENTS[*]} != "container_experiment_local namespace_experiment_local" ]] ; then
 			echo -n "🔄 Installing the required benchmarks..."

--- a/monitoring/local_monitoring/local_monitoring_demo.sh
+++ b/monitoring/local_monitoring/local_monitoring_demo.sh
@@ -39,7 +39,6 @@ function usage() {
 	echo "Usage: $0 [-s|-t] [-c cluster-type] [-f] [-i kruize-image] [-u kruize-ui-image] [-e experiment_type] [ [-b] [-m benchmark-manifests] [-n namespace] [-l] [-d load-duration] ] [-p]"
 	echo "s = start (default), t = terminate"
 	echo "c = supports minikube, kind, aks and openshift cluster-type"
-	echo "f = create environment setup if cluster-type is minikube, kind"
 	echo "i = kruize image. Default - quay.io/kruize/autotune_operator:<version as in pom.xml>"
 	echo "u = Kruize UI Image. Default - quay.io/kruize/kruize-ui:<version as in package.json>"
 	echo "e = supports container, namespace and gpu"
@@ -62,7 +61,6 @@ export KRUIZE_DOCKER_IMAGE=""
 export benchmark_load=0
 export benchmark=0
 export prometheus=0
-export env_setup=0
 export start_demo=1
 export APP_NAMESPACE="default"
 export LOAD_DURATION="1200"
@@ -84,9 +82,6 @@ do
 			;;
 		e)
 			EXPERIMENT_TYPE="${OPTARG}"
-			;;
-		f)
-			env_setup=1
 			;;
 		i)
 			KRUIZE_DOCKER_IMAGE="${OPTARG}"
@@ -135,13 +130,8 @@ elif [ "${EXPERIMENT_TYPE}" == "gpu" ]; then
 		exit 0
 	fi
 else
-	if [ ${env_setup} -ne 1 ]; then
-		export EXPERIMENTS=("container_experiment_local" "namespace_experiment_local")
-		BENCHMARK="self"
-	else
-		export EXPERIMENTS=("container_experiment_sysbench" "namespace_experiment_sysbench")
-		BENCHMARK="sysbench"
-	fi
+  export EXPERIMENTS=("container_experiment_sysbench" "namespace_experiment_sysbench")
+  BENCHMARK="sysbench"
 fi
 
 if [ ${start_demo} -eq 1 ]; then

--- a/monitoring/local_monitoring/vpa_demo/vpa_demo.sh
+++ b/monitoring/local_monitoring/vpa_demo/vpa_demo.sh
@@ -39,7 +39,6 @@ function usage() {
 	echo "Usage: $0 [-s|-t] [-c cluster-type] [-f] [-i kruize-image] [-u kruize-ui-image] [-e experiment_type] [ [-b] [-m benchmark-manifests] [-n namespace] [-l] [-d load-duration] ] [-p]"
 	echo "s = start (default), t = terminate"
 	echo "c = supports minikube, kind, aks and openshift cluster-type"
-	echo "f = create environment setup if cluster-type is minikube, kind"
 	echo "i = kruize image. Default - quay.io/kruize/autotune_operator:<version as in pom.xml>"
 	echo "u = Kruize UI Image. Default - quay.io/kruize/kruize-ui:<version as in package.json>"
 	echo "b = deploy the benchmark."
@@ -61,7 +60,6 @@ export KRUIZE_DOCKER_IMAGE=""
 export benchmark_load=0
 export benchmark=0
 export prometheus=0
-export env_setup=0
 export start_demo=1
 export APP_NAMESPACE="default"
 export LOAD_DURATION="1200"
@@ -80,9 +78,6 @@ do
 			;;
 		d)
 			LOAD_DURATION="${OPTARG}"
-			;;
-		f)
-			env_setup=1
 			;;
 		i)
 			KRUIZE_DOCKER_IMAGE="${OPTARG}"


### PR DESCRIPTION
This PR has the following changes 
1. Removes `-f`option - which enabled fresh environment setup for minikube and kind cluster types.
2. Updates the local monitoring demos to install minikube/kind and prometheus by default instead of setting up using `-f` option

These changes are made following the team's suggestion, keeping in mind user experience and smooth on-boarding for kruize-demos. 