### PR TITLE
Fixed Kruize URL for openshift

### DIFF
--- a/monitoring/remote_monitoring_demo/kruize/kruize.py
+++ b/monitoring/remote_monitoring_demo/kruize/kruize.py
@@ -61,7 +61,7 @@ def form_kruize_url(cluster_type):
         subprocess.run(['oc expose svc/kruize-ui-nginx-service -n openshift-tuning'], shell=True, stdout=subprocess.PIPE)
         ip = subprocess.run(
             [
-                'oc status -n openshift-tuning | grep "kruize-ui-nginx-service" | grep -v "kruize-ui" | grep -v "kruize-db" | grep port | cut -d " " -f1 | cut -d "/" -f3'],
+                'oc status -n openshift-tuning | grep "kruize-ui-nginx-service" | grep port | cut -d " " -f1 | cut -d "/" -f3'],
             shell=True,
             stdout=subprocess.PIPE)
         SERVER_IP = ip.stdout.decode('utf-8').strip('\n')


### PR DESCRIPTION
Fixed Kruize URL issue seen in some of the openshift clusters, by using route instead of IP and PORT in remote monitoring demo