### PR TITLE
Support BSD system in computing elapsed time by demo scripts

### DIFF
--- a/common/common_helper.sh
+++ b/common/common_helper.sh
@@ -32,9 +32,13 @@ function get_date() {
 }
 
 function time_diff() {
-	ssec=`date --utc --date "$1" +%s`
-	esec=`date --utc --date "$2" +%s`
-
+	if date --version > /dev/null 2>&1 ; then
+		ssec=`date --utc --date "$1" +%s`
+		esec=`date --utc --date "$2" +%s`
+	else
+		ssec=`date -j -f "%Y-%m-%d %H:%M:%S" "$1" +%s`
+		esec=`date -j -f "%Y-%m-%d %H:%M:%S" "$2" +%s`
+	fi
 	diffsec=$(($esec-$ssec))
 	echo $diffsec
 }


### PR DESCRIPTION
This PR contain fix to support both GNU and BSD compatible `date` operations. For more details about the issue, refer to issue #159 