### PR TITLE
Update container runtime for minikube

### DIFF
--- a/monitoring/local_monitoring/common.sh
+++ b/monitoring/local_monitoring/common.sh
@@ -449,9 +449,7 @@ function kruize_local_demo_setup() {
 	if [ ! -d "autotune" ]; then
 		echo -n "🔄 Pulling required repositories... "
 		{
-#			clone_repos autotune
-      # Temp cloning to verify the network policy changes, will be reverted, once the PR is approved
-			git clone -b mvp_demo https://github.com/kruize/autotune.git
+			clone_repos autotune
 			if [[ ${#EXPERIMENTS[@]} -ne 0 ]] && [[ ${EXPERIMENTS[*]} != "container_experiment_local" ]] ; then
 				clone_repos benchmarks
 			fi


### PR DESCRIPTION
This PR updates the container-runtime as `containerd` for minikube installation.
Has changes corresponding to the networkpolicy changes of https://github.com/kruize/autotune/pull/1744

## Summary by Sourcery

Set minikube to use containerd as the container runtime by default and temporarily adjust local monitoring demo setup to clone a specific autotune branch for validation.

Enhancements:
- Default the minikube container runtime configuration to containerd and ensure it is passed explicitly on startup.
- Temporarily replace the generic autotune repository cloning helper with a direct clone of the mvp_demo branch in the local monitoring demo setup.