### PR TITLE
Refactor bulk demo and enable operator mode

### DIFF
--- a/common/common_helper.sh
+++ b/common/common_helper.sh
@@ -892,25 +892,9 @@ function kruize_local_bulk_demo_patch() {
 	KRUIZE_CRC_DEPLOY_MANIFEST_OPENSHIFT="${CRC_DIR}/openshift/kruize-crc-openshift.yaml"
 
   if [ ${CLUSTER_TYPE} == "openshift" ]; then
-    
     # Apply the updates
     sed -i 's/\([[:space:]]*\)\(storage:\)[[:space:]]*[0-9]\+Mi/\1\2 1Gi/' ${KRUIZE_CRC_DEPLOY_MANIFEST_OPENSHIFT}
     sed -i 's/\([[:space:]]*\)\(memory:\)[[:space:]]*".*"/\1\2 "2Gi"/; s/\([[:space:]]*\)\(cpu:\)[[:space:]]*".*"/\1\2 "2"/' ${KRUIZE_CRC_DEPLOY_MANIFEST_OPENSHIFT}
-    
-    # Print updated resource values in table format
-    echo
-    echo "📄 Kruize Resources (Bulk Demo - OpenShift)"
-    echo "┌─────────────┬──────────────┬──────────────┐"
-    echo "│ Component   │ CPU (Req/Lim)│ Mem (Req/Lim)│"
-    echo "├─────────────┼──────────────┼──────────────┤"
-    echo "│ Kruize      │ 2 / 2        │ 2Gi / 2Gi    │"
-    echo "│ Kruize DB   │ 2 / 2        │ 2Gi / 2Gi    │"
-    echo "└─────────────┴──────────────┴──────────────┘"
-    echo "DB Storage: PV/PVC = 1Gi"
-    echo
-    echo "ℹ️  Note: For clusters with more containers, consider increasing"
-    echo "   Kruize resources in ${KRUIZE_CRC_DEPLOY_MANIFEST_OPENSHIFT}"
-    echo
   fi
 }
 

--- a/common/common_helper.sh
+++ b/common/common_helper.sh
@@ -883,3 +883,34 @@ function kruize_remote_demo_patch() {
   fi
 }
 
+#
+# Updates kruize default cpu/memory resources, PV storage for openshift only for Bulk demo
+#
+function kruize_local_bulk_demo_patch() {
+  echo "Updating bulk demo resources"
+	CRC_DIR="./autotune/manifests/crc/default-db-included-installation"
+	KRUIZE_CRC_DEPLOY_MANIFEST_OPENSHIFT="${CRC_DIR}/openshift/kruize-crc-openshift.yaml"
+
+  if [ ${CLUSTER_TYPE} == "openshift" ]; then
+    
+    # Apply the updates
+    sed -i 's/\([[:space:]]*\)\(storage:\)[[:space:]]*[0-9]\+Mi/\1\2 1Gi/' ${KRUIZE_CRC_DEPLOY_MANIFEST_OPENSHIFT}
+    sed -i 's/\([[:space:]]*\)\(memory:\)[[:space:]]*".*"/\1\2 "2Gi"/; s/\([[:space:]]*\)\(cpu:\)[[:space:]]*".*"/\1\2 "2"/' ${KRUIZE_CRC_DEPLOY_MANIFEST_OPENSHIFT}
+    
+    # Print updated resource values in table format
+    echo
+    echo "📄 Kruize Resources (Bulk Demo - OpenShift)"
+    echo "┌─────────────┬──────────────┬──────────────┐"
+    echo "│ Component   │ CPU (Req/Lim)│ Mem (Req/Lim)│"
+    echo "├─────────────┼──────────────┼──────────────┤"
+    echo "│ Kruize      │ 2 / 2        │ 2Gi / 2Gi    │"
+    echo "│ Kruize DB   │ 2 / 2        │ 2Gi / 2Gi    │"
+    echo "└─────────────┴──────────────┴──────────────┘"
+    echo "DB Storage: PV/PVC = 1Gi"
+    echo
+    echo "ℹ️  Note: For clusters with more containers, consider increasing"
+    echo "   Kruize resources in ${KRUIZE_CRC_DEPLOY_MANIFEST_OPENSHIFT}"
+    echo
+  fi
+}
+

--- a/common/common_helper.sh
+++ b/common/common_helper.sh
@@ -705,55 +705,13 @@ function kruize_local_patch() {
 	popd >/dev/null
 }
 
-function kruize_local_ros_patch() {
- CRC_DIR="./autotune/manifests/crc/default-db-included-installation"
-	KRUIZE_CRC_DEPLOY_MANIFEST_OPENSHIFT="${CRC_DIR}/openshift/kruize-crc-openshift.yaml"
-	KRUIZE_CRC_DEPLOY_MANIFEST_MINIKUBE="${CRC_DIR}/minikube/kruize-crc-minikube.yaml"
-
-	if [[ ${CLUSTER_TYPE} == "minikube" ]] || [[ ${CLUSTER_TYPE} == "kind" ]]; then
-      		if grep -q '"isROSEnabled": "false"' ${KRUIZE_CRC_DEPLOY_MANIFEST_MINIKUBE}; then
-      		  	echo "Setting flag 'isROSEnabled' to 'true'"
-        		sed -i 's/"isROSEnabled": "false"/"isROSEnabled": "true"/' ${KRUIZE_CRC_DEPLOY_MANIFEST_MINIKUBE}
-
-        		# Use awk to find the 'kruizeconfigjson' block and insert 'metricProfileFilePath' and 'metadataProfileFilePath' before "hibernate"
-        		awk '
-        		/kruizeconfigjson: \|/ {in_config=1}
-        		in_config && /"hibernate":/ {
-            			print "      \"metricProfileFilePath\": \"/home/autotune/app/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.json\",";
-            			print "      \"metadataProfileFilePath\": \"/home/autotune/app/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.json\",";
-            			print
-            			next
-        		}
-        		{print}
-        		' "${KRUIZE_CRC_DEPLOY_MANIFEST_MINIKUBE}" > temp.yaml && mv temp.yaml "${KRUIZE_CRC_DEPLOY_MANIFEST_MINIKUBE}"
-      		fi
-  	elif [ ${CLUSTER_TYPE} == "openshift" ]; then
-  	      if grep -q '"isROSEnabled": "false"' ${KRUIZE_CRC_DEPLOY_MANIFEST_OPENSHIFT}; then
-  	        	echo "Setting flag 'isROSEnabled' to 'true'"
-            		sed -i 's/"isROSEnabled": "false"/"isROSEnabled": "true"/' ${KRUIZE_CRC_DEPLOY_MANIFEST_OPENSHIFT}
-
-            		# Use awk to find the 'kruizeconfigjson' block and insert 'metricProfileFilePath' and 'metadataProfileFilePath' before "hibernate"
-            		awk '
-            		/kruizeconfigjson: \|/ {in_config=1}
-            		in_config && /"hibernate":/ {
-                		print "      \"metricProfileFilePath\": \"/home/autotune/app/manifests/autotune/performance-profiles/resource_optimization_local_monitoring.json\",";
-                		print "      \"metadataProfileFilePath\": \"/home/autotune/app/manifests/autotune/metadata-profiles/bulk_cluster_metadata_local_monitoring.json\",";
-                		print
-                		next
-            		}
-            		{print}
-            		' "${KRUIZE_CRC_DEPLOY_MANIFEST_OPENSHIFT}" > temp.yaml && mv temp.yaml "${KRUIZE_CRC_DEPLOY_MANIFEST_OPENSHIFT}"
-          	fi
-  	fi
-}
-
 
 ###########################################
 #  Get URLs
 ###########################################
 function get_urls() {
-	bench=$1
-	kruize_operator=$2
+	local bench=$1
+	local kruize_operator=$2
 	echo ${kruize_operator}
 	if [ ${CLUSTER_TYPE} == "minikube" ]; then
 		kubectl_cmd="kubectl -n monitoring"

--- a/monitoring/local_monitoring/bulk_demo/README.md
+++ b/monitoring/local_monitoring/bulk_demo/README.md
@@ -50,9 +50,10 @@ w = Wait for the specified seconds for metrics to be available before generating
 n = namespace of benchmark. Default - default
 d = duration to run the benchmark load
 k = install kruize using deploy scripts
+o = specify custom operator image (optional). Default - quay.io/kruize/kruize-operator:<version as in Makefile>
 ```
 
-Note: Kruize Operator doesn't support Bulk API yet, currently only non-operator deployment of Kruize `[-k]` is supported by Bulk demo. Stay tuned for more updates.
+**Note**: By default, Bulk demo uses operator mode with the image version from the Kruize operator Makefile: `quay.io/kruize/kruize-operator:<version>`. You can optionally specify a custom operator image using the `-o` flag.
 
 ## Bulk API configuration
 

--- a/monitoring/local_monitoring/bulk_demo/README.md
+++ b/monitoring/local_monitoring/bulk_demo/README.md
@@ -55,6 +55,17 @@ o = specify custom operator image (optional). Default - quay.io/kruize/kruize-op
 
 **Note**: By default, Bulk demo uses operator mode with the image version from the Kruize operator Makefile: `quay.io/kruize/kruize-operator:<version>`. You can optionally specify a custom operator image using the `-o` flag.
 
+### Kruize Resource Configuration
+
+The bulk demo automatically configures Kruize with the following resources for OpenShift deployments:
+
+| Component   | CPU (Req/Lim) | Memory (Req/Lim) | Storage     |
+|-------------|---------------|------------------|-------------|
+| Kruize      | 2 / 2         | 2Gi / 2Gi        | -           |
+| Kruize DB   | 2 / 2         | 2Gi / 2Gi        | 1Gi (PV/PVC)|
+
+**Note**: For clusters with a large number of containers, consider increasing Kruize resources by modifying the manifest file at `bulk_demo/autotune/manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml` before running the demo.
+
 ## Bulk API configuration
 
 The user can modify the bulk API JSON configuration to specify or omit certain namespaces, workloads, or containers for which recommendations need to be generated.

--- a/monitoring/local_monitoring/bulk_demo/bulk_service_demo.sh
+++ b/monitoring/local_monitoring/bulk_demo/bulk_service_demo.sh
@@ -37,7 +37,7 @@ KIND_IP=127.0.0.1
 KRUIZE_PORT=8080
 KRUIZE_UI_PORT=8081
 TECHEMPOWER_PORT=8082
-KRUIZE_OPERATOR=0
+KRUIZE_OPERATOR=1
 BENCHMARK=""
 
 PYTHON_CMD=python3
@@ -133,7 +133,6 @@ do
 			;;
 		o) 
 			KRUIZE_OPERATOR_IMAGE="${OPTARG}"
-			KRUIZE_OPERATOR=1
 			;;
     		k)
       			KRUIZE_OPERATOR=0
@@ -147,7 +146,6 @@ export demo="bulk"
 
 if [[ "${CLUSTER_TYPE}" == "minikube" ]] || [[ "${CLUSTER_TYPE}" == "kind" ]]; then
   NAMESPACE="monitoring"
-  KRUIZE_OPERATOR=0
 else
   NAMESPACE="openshift-tuning"
 fi
@@ -156,14 +154,21 @@ validate_wait_time
 
 if [ ${start_demo} -eq 1 ]; then
 	echo > "${LOG_FILE}" 2>&1
-	kruize_local_demo_setup ${BENCHMARK} ${KRUIZE_OPERATOR}
+
+	if [ ${KRUIZE_OPERATOR} -eq 1 ]; then
+	  # Check Go prerequisite before proceeding
+	  check_go_prerequisite
+	  check_err "ERROR: Go pre-requisite check failed. Cannot proceed with operator deployment."
+	fi
+
+	kruize_local_demo_setup "${BENCHMARK}" "${KRUIZE_OPERATOR}"
 	echo "For detailed logs, look in kruize-bulk-demo.log"
 	echo
 elif [ ${start_demo} -eq 2 ]; then
 	kruize_local_demo_update
 else
 	echo >> "${LOG_FILE}" 2>&1
-	kruize_local_demo_terminate ${KRUIZE_OPERATOR}
+	kruize_local_demo_terminate "${KRUIZE_OPERATOR}"
 	echo "For detailed logs, look in kruize-bulk-demo.log"
 	echo
 fi

--- a/monitoring/local_monitoring/common.sh
+++ b/monitoring/local_monitoring/common.sh
@@ -516,7 +516,7 @@ function kruize_local_demo_setup() {
 	kruize_local_patch >> "${LOG_FILE}" 2>&1
 
 	if [[ ${demo} == "bulk" ]] && [[ ${kruize_operator} -eq 0 ]]; then
-	     kruize_local_bulk_demo_patch | tee -a "${LOG_FILE}"
+	     kruize_local_bulk_demo_patch >> "${LOG_FILE}" 2>&1
 	 fi
 
 

--- a/monitoring/local_monitoring/common.sh
+++ b/monitoring/local_monitoring/common.sh
@@ -395,14 +395,14 @@ function kruize_local_demo_setup() {
 	if [ "$cluster_accessible" = true ]; then
 		# Check for operator deployment
 		operator_deployment=$(kubectl get deployment $OPERATOR_DEPLOYMENT_NAME -n ${NAMESPACE} 2>&1)
-		
+
 		# Check for kruize pods
 		kruize_pods=$(kubectl get pod -l app=kruize -n ${NAMESPACE} 2>&1)
-		
+
 		if [[ ! "$operator_deployment" =~ "NotFound" ]] && [[ ! "$operator_deployment" =~ "No resources" ]]; then
 			operator_exists=true
 		fi
-		
+
 		if [[ ! "$kruize_pods" =~ "NotFound" ]] && [[ ! "$kruize_pods" =~ "No resources" ]]; then
 			kruize_exists=true
 		fi
@@ -515,10 +515,6 @@ function kruize_local_demo_setup() {
 
 	kruize_local_patch >> "${LOG_FILE}" 2>&1
 
-	if [ ${demo} == "bulk" ]; then
-        	kruize_local_ros_patch >> "${LOG_FILE}" 2>&1
-	fi
-
 	echo -n "🔄 Installing Kruize! Please wait..."
 	kruize_start_time=$(get_date)
 	if [[ "${kruize_operator}" -eq 1 ]]; then
@@ -563,15 +559,13 @@ function kruize_local_demo_setup() {
 	}
 	fi
 
-       if [ ${demo} != "bulk" ]; then
-         echo -n "🔄 Installing metric profile..."
-         kruize_local_metric_profile
-         echo "✅ Installation of metric profile complete!"
+	echo -n "🔄 Installing metric profile..."
+	kruize_local_metric_profile
+	echo "✅ Installation of metric profile complete!"
 
-         echo -n "🔄 Installing metadata profile..."
-         kruize_local_metadata_profile
-         echo "✅ Installation of metadata profile complete!"
-       fi
+	echo -n "🔄 Installing metadata profile..."
+	kruize_local_metadata_profile
+	echo "✅ Installation of metadata profile complete!"
 
 	if [ ${demo} == "local" ]; then
 		echo -n "🔄 Collecting metadata..."
@@ -636,11 +630,11 @@ operator_setup() {
 
 	echo "🔄 Checking for existence of $NAMESPACE namespace"
 
-    	if oc get ns $NAMESPACE >/dev/null 2>&1; then
+    	if kubectl get ns $NAMESPACE >/dev/null 2>&1; then
           	echo "Namespace ${NAMESPACE} exists"
     	else
       		echo "Namespace ${NAMESPACE} does not exist"
-      		oc create ns $NAMESPACE
+      		kubectl create ns $NAMESPACE
       		check_err "ERROR: Failed to create $NAMESPACE namespace"
     	fi
 

--- a/monitoring/local_monitoring/common.sh
+++ b/monitoring/local_monitoring/common.sh
@@ -379,6 +379,18 @@ function kruize_local_demo_setup() {
 	echo "#######################################" | tee -a "${LOG_FILE}"
 	echo
 
+	# Clone repos first if not already present (needed for cleanup functions)
+	if [ ! -d "autotune" ]; then
+		echo -n "🔄 Pulling required repositories... "
+		{
+			clone_repos autotune
+			if [[ ${#EXPERIMENTS[@]} -ne 0 ]] && [[ ${EXPERIMENTS[*]} != "container_experiment_local" ]] ; then
+				clone_repos benchmarks
+			fi
+		} >> "${LOG_FILE}" 2>&1
+		echo "✅ Done!"
+	fi
+
 	# Check for both operator and kruize deployments
 	echo -n "🔍 Checking if Kruize deployment is running..."
 	
@@ -446,18 +458,6 @@ function kruize_local_demo_setup() {
 		echo " Done!"
 	else
 		echo " Not running."
-	fi
-
-	# Clone repos if not already present
-	if [ ! -d "autotune" ]; then
-		echo -n "🔄 Pulling required repositories... "
-		{
-			clone_repos autotune
-			if [[ ${#EXPERIMENTS[@]} -ne 0 ]] && [[ ${EXPERIMENTS[*]} != "container_experiment_local" ]] ; then
-				clone_repos benchmarks
-			fi
-		} >> "${LOG_FILE}" 2>&1
-		echo "✅ Done!"
 	fi
 
 	if [[ ${env_setup} -eq 1 ]]; then

--- a/monitoring/local_monitoring/common.sh
+++ b/monitoring/local_monitoring/common.sh
@@ -515,6 +515,11 @@ function kruize_local_demo_setup() {
 
 	kruize_local_patch >> "${LOG_FILE}" 2>&1
 
+	if [[ ${demo} == "bulk" ]] && [[ ${kruize_operator} -eq 0 ]]; then
+	     kruize_local_bulk_demo_patch | tee -a "${LOG_FILE}"
+	 fi
+
+
 	echo -n "🔄 Installing Kruize! Please wait..."
 	kruize_start_time=$(get_date)
 	if [[ "${kruize_operator}" -eq 1 ]]; then
@@ -742,7 +747,7 @@ operator_setup() {
 	timeout=180
 	elapsed=0
 	while [ $elapsed -lt $timeout ]; do
-		if kubectl get pod -l app=kruize-ui-nginx -n $NAMESPACE --no-headers 2>/dev/null | grep -q kruize-ui-nginx; then
+		if kubectl get pod -l app=kruize-ui-nginx -n $NAMESPACE --no-headers 2>/dev/null | grep -q .; then
 			break
 		fi
 		echo -n "."


### PR DESCRIPTION
This PR has the following changes:

- Enables operator mode support as the default in bulk demos
- Removes `kruize_local_ros_patch() `and instead creates the profiles using APIs

## Summary by Sourcery

Default bulk local monitoring demo to use the operator-based deployment path and rely on API-driven profile installation instead of manifest patching.

New Features:
- Enable operator mode by default for the bulk local monitoring demo.
- Ensure bulk demos always create metric and metadata profiles via the standard profile APIs regardless of demo type.

Enhancements:
- Remove the ROS-specific manifest patch helper and the associated bulk demo conditional logic.
- Standardize namespace existence checks in operator setup to use kubectl instead of oc for local monitoring flows.
- Tighten local variable scoping in URL helper scripts and pass operator mode flags explicitly to demo lifecycle functions.