### PR TITLE
Use manifests specific to kruize-demos which runs load internally for techempower and petclinic benchmarks

### DIFF
--- a/common/common_helper.sh
+++ b/common/common_helper.sh
@@ -477,7 +477,6 @@ function apply_benchmark_load() {
 	APP_NAMESPACE="${1:-${APP_NAMESPACE}}"
 	BENCHMARK="${2:-tfb}"
 	LOAD_DURATION="${3:-1200}"
-	BENCHMARK2="${4:-petclinic}"
 
 	if [ ${BENCHMARK} == "tfb" ]; then
 		if kubectl get pods --namespace ${APP_NAMESPACE} -o jsonpath='{.items[*].metadata.name}' | grep -q "tfb"; then
@@ -497,7 +496,7 @@ function apply_benchmark_load() {
 			docker run -d --rm --network="host"  ${TECHEMPOWER_LOAD_IMAGE} /opt/run_hyperfoil_load.sh ${TECHEMPOWER_ROUTE} queries?queries=20 ${LOAD_DURATION} 512 4096 #1024 8096
 		fi
 	fi
-	if [ ${BENCHMARK2} == "petclinic" ]; then
+	if [ ${BENCHMARK} == "petclinic" ]; then
 		if kubectl get pods --namespace ${APP_NAMESPACE} -o jsonpath='{.items[*].metadata.name}' | grep -q "petclinic"; then
 			echo
 			echo "################################################################################################################"

--- a/common/common_helper.sh
+++ b/common/common_helper.sh
@@ -368,8 +368,11 @@ function benchmarks_install() {
 		if [ ${BENCHMARK} == "petclinic" ]; then
 			echo "5. Installing spring petclinic benchmark into cluster"
 			pushd spring-petclinic >/dev/null
-
-			kubectl apply -f manifests/${MANIFESTS} -n ${APP_NAMESPACE}
+			if [ "${MANIFESTS}" != "default_manifests" ]; then
+				kubectl apply -f manifests/${MANIFESTS} -n ${APP_NAMESPACE}
+		    	else
+				kubectl apply -f manifests/*.yaml -n ${APP_NAMESPACE}
+		    	fi
 			check_err "ERROR: spring petclinic failed to start, exiting"
 			popd >/dev/null
 		fi

--- a/common/common_helper.sh
+++ b/common/common_helper.sh
@@ -349,7 +349,6 @@ function benchmarks_install() {
 	APP_NAMESPACE="${1:-${APP_NAMESPACE}}"
 	BENCHMARK="${2:-tfb}"
 	MANIFESTS="${3:-default_manifests}"
-	BENCHMARK2="${4:-petclinic}"
 
 	echo
 	echo "#######################################"
@@ -366,11 +365,11 @@ function benchmarks_install() {
 			check_err "ERROR: TechEmpower app failed to start, exiting"
 			popd >/dev/null
 		fi
-		if [ ${BENCHMARK2} == "petclinic" ]; then
+		if [ ${BENCHMARK} == "petclinic" ]; then
 			echo "5. Installing spring petclinic benchmark into cluster"
 			pushd spring-petclinic >/dev/null
 
-			kubectl apply -f manifests -n ${APP_NAMESPACE}
+			kubectl apply -f manifests/${MANIFESTS} -n ${APP_NAMESPACE}
 			check_err "ERROR: spring petclinic failed to start, exiting"
 			popd >/dev/null
 		fi

--- a/monitoring/local_monitoring/common.sh
+++ b/monitoring/local_monitoring/common.sh
@@ -541,8 +541,8 @@ function kruize_local_demo_setup() {
 		if [[ ${#EXPERIMENTS[@]} -ne 0 ]] && [[ ${EXPERIMENTS[*]} != "container_experiment_local namespace_experiment_local" ]] ; then
 			echo -n "🔄 Installing the required benchmarks..."
 			create_namespace ${APP_NAMESPACE} >> "${LOG_FILE}" 2>&1
-			benchmarks_install ${APP_NAMESPACE} ${bench} "" ${bench2} >> "${LOG_FILE}" 2>&1
-			apply_benchmark_load ${APP_NAMESPACE} ${bench} "" ${bench2} >> "${LOG_FILE}" 2>&1
+			benchmarks_install ${APP_NAMESPACE} ${bench} "kruize-runtimes" ${bench2} >> "${LOG_FILE}" 2>&1
+			apply_benchmark_load ${APP_NAMESPACE} ${bench2} >> "${LOG_FILE}" 2>&1
 			echo "✅ Completed!"
 		fi
 		echo "" >> "${LOG_FILE}" 2>&1

--- a/monitoring/local_monitoring/common.sh
+++ b/monitoring/local_monitoring/common.sh
@@ -541,9 +541,28 @@ function kruize_local_demo_setup() {
 		if [[ ${#EXPERIMENTS[@]} -ne 0 ]] && [[ ${EXPERIMENTS[*]} != "container_experiment_local namespace_experiment_local" ]] ; then
 			echo -n "🔄 Installing the required benchmarks..."
 			create_namespace ${APP_NAMESPACE} >> "${LOG_FILE}" 2>&1
-			benchmarks_install ${APP_NAMESPACE} ${bench} "kruize-runtimes" ${bench2} >> "${LOG_FILE}" 2>&1
-			apply_benchmark_load ${APP_NAMESPACE} ${bench2} >> "${LOG_FILE}" 2>&1
+			# Clean up any existing load job so the new one can start fresh
+			echo "Cleaning up any old load jobs..." >> "${LOG_FILE}" 2>&1
+			kubectl delete job petclinic-load-generator -n ${APP_NAMESPACE} --ignore-not-found >> "${LOG_FILE}" 2>&1
+			kubectl delete job tfb-qrh-load-generator -n ${APP_NAMESPACE} --ignore-not-found >> "${LOG_FILE}" 2>&1
+
+			benchmarks_install ${APP_NAMESPACE} ${bench} "kruize-demos" ${bench2} >> "${LOG_FILE}" 2>&1
+			benchmarks_install ${APP_NAMESPACE} ${bench2} "kruize-demos" >> "${LOG_FILE}" 2>&1
 			echo "✅ Completed!"
+		fi
+		quarkus_label="com.redhat.component-name=Quarkus"
+		if [[ ${CLUSTER_TYPE} == "minikube" ]] || [[ ${CLUSTER_TYPE} == "kind" ]]; then
+			quarkus_pod_name=$(kubectl get pod | grep tfb-qrh-sample | cut -d " " -f1)
+			kubectl label pod "${quarkus_pod_name}" "${quarkus_label}" >> "${LOG_FILE}" 2>&1
+			echo -n "🔄 Enabling kube state metrics labels..."
+			./autotune/scripts/enable_kube_state_metrics_labels.sh >> "${LOG_FILE}" 2>&1
+			echo "✅ Complete!"
+		else
+			quarkus_pod_name=$(oc get pod | grep tfb-qrh-sample | cut -d " " -f1)
+			oc label pod "${quarkus_pod_name}" "${quarkus_label}" >> "${LOG_FILE}" 2>&1
+			echo -n "🔄 Enabling user workload monitoring..."
+			./autotune/scripts/enable_user_workload_monitoring_openshift.sh >> "${LOG_FILE}" 2>&1
+			echo "✅ Complete!"
 		fi
 		echo "" >> "${LOG_FILE}" 2>&1
 	fi
@@ -647,21 +666,6 @@ function kruize_local_demo_setup() {
 		kruize_bulk
 		recomm_end_time=$(get_date)
 	elif [ ${demo} == "runtimes" ]; then
-		quarkus_label="com.redhat.component-name=Quarkus"
-		if [[ ${CLUSTER_TYPE} == "minikube" ]] || [[ ${CLUSTER_TYPE} == "kind" ]]; then
-			quarkus_pod_name=$(kubectl get pod | grep tfb-qrh | cut -d " " -f1)
-			kubectl label pod "${quarkus_pod_name}" "${quarkus_label}" >> "${LOG_FILE}" 2>&1
-			echo -n "🔄 Enabling kube state metrics labels..."
-	                ./autotune/scripts/enable_kube_state_metrics_labels.sh >> "${LOG_FILE}" 2>&1
-			echo "✅ Complete!"
-	        else
-			quarkus_pod_name=$(oc get pod | grep tfb-qrh | cut -d " " -f1)
-			oc label pod "${quarkus_pod_name}" "${quarkus_label}" >> "${LOG_FILE}" 2>&1
-			echo -n "🔄 Enabling user workload monitoring..."
-			./autotune/scripts/enable_user_workload_monitoring_openshift.sh >> "${LOG_FILE}" 2>&1
-			echo "✅ Complete!"
-        	fi
-
 		echo -n "🔄 Collecting metadata..."
 		kruize_local_metadata
 		echo "✅ Collection of metadata complete!"

--- a/monitoring/local_monitoring/common.sh
+++ b/monitoring/local_monitoring/common.sh
@@ -546,7 +546,7 @@ function kruize_local_demo_setup() {
 			kubectl delete job petclinic-load-generator -n ${APP_NAMESPACE} --ignore-not-found >> "${LOG_FILE}" 2>&1
 			kubectl delete job tfb-qrh-load-generator -n ${APP_NAMESPACE} --ignore-not-found >> "${LOG_FILE}" 2>&1
 
-			benchmarks_install ${APP_NAMESPACE} ${bench} "kruize-demos" ${bench2} >> "${LOG_FILE}" 2>&1
+			benchmarks_install ${APP_NAMESPACE} ${bench} "kruize-demos" >> "${LOG_FILE}" 2>&1
 			benchmarks_install ${APP_NAMESPACE} ${bench2} "kruize-demos" >> "${LOG_FILE}" 2>&1
 			echo "✅ Completed!"
 		fi

--- a/monitoring/local_monitoring/runtimes_demo/README.md
+++ b/monitoring/local_monitoring/runtimes_demo/README.md
@@ -83,7 +83,10 @@ c = supports minikube, kind and openshift cluster-type
 f = create environment setup if cluster-type is minikube, kind
 i = kruize image. Default - quay.io/kruize/autotune_operator:<version as in pom.xml>
 o = Kruize operator image. Default - quay.io/kruize/kruize-operator:<version as in Makefile>
+u = kruize ui image. Default - quay.io/kruize/kruize-ui:<version as in package.json>
 k = Disable operator and install kruize using deploy scripts instead.
+n = namespace where benchmarks deploys. Default - default
+p = expose prometheus port
 ```
 
 Refer to the Kruize operator documentation [README.md](https://github.com/kruize/kruize-operator/blob/main/README.md) and [Makefile](https://github.com/kruize/kruize-operator/blob/main/Makefile) for more details.

--- a/monitoring/local_monitoring/runtimes_demo/runtimes_demo.sh
+++ b/monitoring/local_monitoring/runtimes_demo/runtimes_demo.sh
@@ -42,18 +42,14 @@ PETCLINIC_PORT=8083
 KRUIZE_OPERATOR=1
 
 function usage() {
-	echo "Usage: $0 [-s|-t] [-c cluster-type] [-f] [-i kruize-image] [-u kruize-ui-image] [ [-b] [-m benchmark-manifests] [-n namespace] [-l] [-d load-duration] ] [-p] [-o kruize operator image] [-k]"
+	echo "Usage: $0 [-s|-t] [-c cluster-type] [-f] [-i kruize-image] [-u kruize-ui-image] [ [-n namespace] ] [-p] [-o kruize operator image] [-k]"
 	echo "s = start (default), t = terminate"
 	echo "c = supports minikube, kind and openshift cluster-type"
 	echo "f = create environment setup if cluster-type is minikube, kind"
 	echo "i = kruize image. Default - quay.io/kruize/autotune_operator:<version as in pom.xml>"
 	echo "u = Kruize UI Image. Default - quay.io/kruize/kruize-ui:<version as in package.json>"
 	echo "o = Kruize operator image. Default - quay.io/kruize/kruize-operator:<version as in Makefile>"
-	echo "b = deploy the benchmark."
-	echo "m = manifests of the benchmark"
 	echo "n = namespace of benchmark. Default - default"
-	echo "l = Run a load against the benchmark"
-	echo "d = duration to run the benchmark load"
 	echo "p = expose prometheus port"
 	echo "k = Disable operator and install kruize using deploy scripts instead."
 
@@ -72,7 +68,7 @@ export EXPERIMENT_TYPE=""
 export KRUIZE_OPERATOR_IMAGE=""
 
 # Iterate through the commandline options
-while getopts c:kfi:m:no:pstu: gopts
+while getopts c:kfi:no:pstu: gopts
 do
 	case "${gopts}" in
 		c)
@@ -83,9 +79,6 @@ do
 			;;
 		i)
 			KRUIZE_DOCKER_IMAGE="${OPTARG}"
-			;;
-		m)
-			BENCHMARK_MANIFESTS="${OPTARG}"
 			;;
 		n)
 			export APP_NAMESPACE="${OPTARG}"

--- a/monitoring/local_monitoring/runtimes_demo/runtimes_demo.sh
+++ b/monitoring/local_monitoring/runtimes_demo/runtimes_demo.sh
@@ -63,13 +63,10 @@ function usage() {
 # By default we start the demo and dont expose prometheus port
 export DOCKER_IMAGES=""
 export KRUIZE_DOCKER_IMAGE=""
-export benchmark_load=0
-export benchmark=0
 export prometheus=0
 export env_setup=0
 export start_demo=1
 export APP_NAMESPACE="default"
-export LOAD_DURATION="1200"
 export BENCHMARK_MANIFESTS="resource_provisioning_manifests"
 export EXPERIMENT_TYPE=""
 export KRUIZE_OPERATOR_IMAGE=""
@@ -78,25 +75,14 @@ export KRUIZE_OPERATOR_IMAGE=""
 while getopts bc:d:kfi:lm:no:pstu: gopts
 do
 	case "${gopts}" in
-		b)
-			start_demo=2
-			benchmark=1
-			;;
 		c)
 			CLUSTER_TYPE="${OPTARG}"
-			;;
-		d)
-			LOAD_DURATION="${OPTARG}"
 			;;
 		f)
 			env_setup=1
 			;;
 		i)
 			KRUIZE_DOCKER_IMAGE="${OPTARG}"
-			;;
-		l)
-			start_demo=2
-			benchmark_load=1
 			;;
 		m)
 			BENCHMARK_MANIFESTS="${OPTARG}"
@@ -152,8 +138,6 @@ if [ ${start_demo} -eq 1 ]; then
 	kruize_local_demo_setup ${BENCHMARK} ${KRUIZE_OPERATOR} ${BENCHMARK2}
 	echo "For detailed logs, look in kruize-demo.log"
 	echo
-elif [ ${start_demo} -eq 2 ]; then
-	kruize_local_demo_update ${BENCHMARK}
 else
 	echo >> "${LOG_FILE}" 2>&1
 	kruize_local_demo_terminate

--- a/monitoring/local_monitoring/runtimes_demo/runtimes_demo.sh
+++ b/monitoring/local_monitoring/runtimes_demo/runtimes_demo.sh
@@ -63,7 +63,7 @@ export prometheus=0
 export env_setup=0
 export start_demo=1
 export APP_NAMESPACE="default"
-export BENCHMARK_MANIFESTS="resource_provisioning_manifests"
+export BENCHMARK_MANIFESTS="kruize-demos"
 export EXPERIMENT_TYPE=""
 export KRUIZE_OPERATOR_IMAGE=""
 

--- a/monitoring/local_monitoring/runtimes_demo/runtimes_demo.sh
+++ b/monitoring/local_monitoring/runtimes_demo/runtimes_demo.sh
@@ -72,7 +72,7 @@ export EXPERIMENT_TYPE=""
 export KRUIZE_OPERATOR_IMAGE=""
 
 # Iterate through the commandline options
-while getopts bc:d:kfi:lm:no:pstu: gopts
+while getopts c:kfi:m:no:pstu: gopts
 do
 	case "${gopts}" in
 		c)


### PR DESCRIPTION
Instead of running load externally in a tfb-benchmark, use the manifests of the benchmark which runs the load internally in the tfb-qrh pod. 

Uses the manifests from https://github.com/kruize/benchmarks/pull/71

## Summary by Sourcery

Update local monitoring benchmark setup to run TechEmpower load generation from within the tfb container/manifests instead of externally and align helper script parameters with the new behavior.

Enhancements:
- Adjust benchmark installation to use the internal tfb runtime manifests and simplify load application to target the second benchmark only.
- Refine apply_benchmark_load helper to treat petclinic consistently as the primary benchmark argument and remove the unused secondary benchmark parameter.

## Summary by Sourcery

Switch local monitoring demo benchmarks to use kruize-demos-specific manifests and internal load generation for TechEmpower and Petclinic, while centralizing Quarkus pod labeling and monitoring setup.

Enhancements:
- Clean up existing TechEmpower and Petclinic load jobs before reinstalling benchmarks in the local demo setup.
- Update benchmark installation to accept a manifests variant (e.g., kruize-demos) and apply Petclinic manifests from that path.
- Remove the secondary benchmark parameter and treat Petclinic as a primary benchmark option in both benchmark installation and load application helpers.
- Move Quarkus pod labeling and monitoring enablement into the main demo setup flow and remove the duplicated logic from the runtimes demo branch.