### PR TITLE
Included an option to install kruize using helm charts in Local monitoring demo

### DIFF
--- a/common/common_helper.sh
+++ b/common/common_helper.sh
@@ -537,7 +537,7 @@ function apply_benchmark_load() {
 #  Expose Prometheus port
 ###########################################
 function expose_prometheus() {
-	kubectl_cmd="kubectl -n monitoring"
+	kubectl_cmd="kubectl -n ${NAMESPACE}"
 	echo "8. Port forwarding Prometheus"
 	echo "Info: Prometheus accessible at http://localhost:9090"
 	${kubectl_cmd} port-forward prometheus-k8s-1 9090:9090
@@ -686,7 +686,7 @@ function kill_service_port_forward() {
 ###########################################
 function port_forward() {
 	local benchmark="${1:-}"
-	kubectl_cmd="kubectl -n monitoring"
+	kubectl_cmd="kubectl -n ${NAMESPACE}"
 	port_flag="false"
 
 	{
@@ -697,14 +697,22 @@ function port_forward() {
 		echo "Error: Port ${KRUIZE_PORT} is already in use. Port forwarding for kruize service cannot be established."
 		port_flag="true"
 	else
-		${kubectl_cmd} port-forward svc/kruize ${KRUIZE_PORT}:8080 > /dev/null 2>&1 &
+		if [ "${KRUIZE_HELM}" == "1" ]; then
+			${kubectl_cmd} port-forward svc/${release} ${KRUIZE_PORT}:8080 > /dev/null 2>&1 &
+		else
+			${kubectl_cmd} port-forward svc/kruize ${KRUIZE_PORT}:8080 > /dev/null 2>&1 &
+		fi
 	fi
 	# Start port forwarding for kruize-ui-nginx-service in the background
 	if is_port_in_use ${KRUIZE_UI_PORT}; then
 		echo "Error: Port ${KRUIZE_UI_PORT} is already in use. Port forwarding for kruize-ui-nginx-service cannot be established."
 		port_flag="true"
 	else
-		${kubectl_cmd} port-forward svc/kruize-ui-nginx-service ${KRUIZE_UI_PORT}:8080 > /dev/null 2>&1 &
+		if [ "${KRUIZE_HELM}" == "1" ]; then
+			${kubectl_cmd} port-forward svc/${release}-ui-nginx-service ${KRUIZE_UI_PORT}:8080 > /dev/null 2>&1 &
+		else
+			${kubectl_cmd} port-forward svc/kruize-ui-nginx-service ${KRUIZE_UI_PORT}:8080 > /dev/null 2>&1 &
+		fi
 	fi
 	# Start port forwarding for tfb-service in the background only if benchmark is tfb
 	if [[ "${benchmark}" == "tfb" ]]; then
@@ -767,13 +775,18 @@ function get_urls() {
 
 	echo ${kruize_operator}
 	if [ ${CLUSTER_TYPE} == "minikube" ]; then
-		kubectl_cmd="kubectl -n monitoring"
+		kubectl_cmd="kubectl -n ${NAMESPACE}"
 		kubectl_app_cmd="kubectl -n ${APP_NAMESPACE}"
 
 		MINIKUBE_IP=$(minikube ip)
-
-		KRUIZE_PORT=$(${kubectl_cmd} get svc kruize --no-headers -o=custom-columns=PORT:.spec.ports[*].nodePort)
-		KRUIZE_UI_PORT=$(${kubectl_cmd} get svc kruize-ui-nginx-service --no-headers -o=custom-columns=PORT:.spec.ports[*].nodePort)
+		
+		if [ "${KRUIZE_HELM}" == "1" ]; then
+			KRUIZE_PORT=$(${kubectl_cmd} get svc ${release} --no-headers -o=custom-columns=PORT:.spec.ports[*].nodePort)
+			KRUIZE_UI_PORT=$(${kubectl_cmd} get svc ${release}-ui-nginx-service --no-headers -o=custom-columns=PORT:.spec.ports[*].nodePort)
+		else
+			KRUIZE_PORT=$(${kubectl_cmd} get svc kruize --no-headers -o=custom-columns=PORT:.spec.ports[*].nodePort)
+			KRUIZE_UI_PORT=$(${kubectl_cmd} get svc kruize-ui-nginx-service --no-headers -o=custom-columns=PORT:.spec.ports[*].nodePort)
+		fi
 
 		export KRUIZE_URL="${MINIKUBE_IP}:${KRUIZE_PORT}"
 		export KRUIZE_UI_URL="${MINIKUBE_IP}:${KRUIZE_UI_PORT}"
@@ -790,11 +803,16 @@ function get_urls() {
 		fi
 
 	elif [ "${CLUSTER_TYPE}" == "aks" ]; then
-		kubectl_cmd="kubectl -n monitoring"
+		kubectl_cmd="kubectl -n ${NAMESPACE}"
 
 		# Expose kruize/kruize-ui-nginx-service via LoadBalancer
-		KRUIZE_SERVICE_URL=$(${kubectl_cmd} get svc kruize -o custom-columns=EXTERNAL-IP:.status.loadBalancer.ingress[*].ip --no-headers)
-		KRUIZE_UI_SERVICE_URL=$(${kubectl_cmd} get svc kruize-ui-nginx-service -o custom-columns=EXTERNAL-IP:.status.loadBalancer.ingress[*].ip --no-headers)
+		if [ "${KRUIZE_HELM}" == "1" ]; then
+			KRUIZE_SERVICE_URL=$(${kubectl_cmd} get svc ${release} -o custom-columns=EXTERNAL-IP:.status.loadBalancer.ingress[*].ip --no-headers)
+			KRUIZE_UI_SERVICE_URL=$(${kubectl_cmd} get svc ${release}-ui-nginx-service -o custom-columns=EXTERNAL-IP:.status.loadBalancer.ingress[*].ip --no-headers)
+		else
+			KRUIZE_SERVICE_URL=$(${kubectl_cmd} get svc kruize -o custom-columns=EXTERNAL-IP:.status.loadBalancer.ingress[*].ip --no-headers)
+			KRUIZE_UI_SERVICE_URL=$(${kubectl_cmd} get svc kruize-ui-nginx-service -o custom-columns=EXTERNAL-IP:.status.loadBalancer.ingress[*].ip --no-headers)
+		fi
 
 		export KRUIZE_URL="${KRUIZE_SERVICE_URL}:8080"
 		export KRUIZE_UI_URL="${KRUIZE_UI_SERVICE_URL}:8080"
@@ -822,13 +840,19 @@ function get_urls() {
 		export KRUIZE_UI_URL="127.0.0.1:8080"
 
 	elif [ ${CLUSTER_TYPE} == "openshift" ]; then
-		kubectl_cmd="oc -n openshift-tuning"
+		kubectl_cmd="oc -n ${NAMESPACE}"
 		kubectl_app_cmd="oc -n ${APP_NAMESPACE}"
 
-		${kubectl_cmd} expose service kruize
-    		${kubectl_cmd} expose service kruize-ui-nginx-service
+		if [ "${KRUIZE_HELM}" == 1 ]; then
+			${kubectl_cmd} expose service ${release}
+    			${kubectl_cmd} expose service ${release}-ui-nginx-service
+			${kubectl_cmd} annotate route ${release} --overwrite haproxy.router.openshift.io/timeout=60s
+		else
+			${kubectl_cmd} expose service kruize
+    			${kubectl_cmd} expose service kruize-ui-nginx-service
+			${kubectl_cmd} annotate route kruize --overwrite haproxy.router.openshift.io/timeout=60s
+		fi
 
-		${kubectl_cmd} annotate route kruize --overwrite haproxy.router.openshift.io/timeout=60s
 
 		if [[ ${demo} == "local" || ${demo} == "runtimes" ]] && [[ ${bench} == "tfb" ]]; then
 			${kubectl_app_cmd} expose service tfb-qrh-service
@@ -842,6 +866,9 @@ function get_urls() {
     		if [[ "${kruize_operator}" -eq 1 ]]; then
 			export KRUIZE_URL=$(${kubectl_cmd} get route kruize -o jsonpath='{.spec.host}')
 			export KRUIZE_UI_URL=$(${kubectl_cmd} get route kruize-ui-nginx-service --no-headers -o wide -o=custom-columns=NODE:.spec.host)
+		elif [[ "${KRUIZE_HELM}" -eq 1 ]]; then 
+			export KRUIZE_URL=$(${kubectl_cmd} get route ${release} -o jsonpath='{.spec.host}')
+			export KRUIZE_UI_URL=$(${kubectl_cmd} get route ${release}-ui-nginx-service --no-headers -o wide -o=custom-columns=NODE:.spec.host)
 		else
 			export KRUIZE_URL=$(${kubectl_cmd} get route kruize --no-headers -o wide -o=custom-columns=NODE:.spec.host)
 			export KRUIZE_UI_URL=$(${kubectl_cmd} get route kruize-ui-nginx-service --no-headers -o wide -o=custom-columns=NODE:.spec.host)

--- a/monitoring/local_monitoring/common.sh
+++ b/monitoring/local_monitoring/common.sh
@@ -40,6 +40,7 @@ function kruize_local_metric_profile() {
 		echo "#     Install default metric profile"
 		echo "#####################################################"
 		echo
+		echo "curl -X POST http://${KRUIZE_URL}/createMetricProfile -d @$resource_optimization_local_monitoring"
 		output=$(curl -X POST http://${KRUIZE_URL}/createMetricProfile -d @$resource_optimization_local_monitoring)
 		echo
 	} >> "${LOG_FILE}" 2>&1
@@ -269,7 +270,8 @@ function kruize_local_experiments() {
 }
 
 function kruize_local_demo_terminate() {
-  kruize_operator=$1
+	kruize_operator=$1
+  	kruize_helm=$2
 	start_time=$(get_date)
 	echo | tee -a "${LOG_FILE}"
 	echo "#######################################" | tee -a "${LOG_FILE}"
@@ -280,6 +282,10 @@ function kruize_local_demo_terminate() {
 
     	if [[ "${kruize_operator}" -eq 1 ]]; then
          	 kruize_operator_cleanup $NAMESPACE >> "${LOG_FILE}" 2>&1
+    	fi
+
+    	if [[ "${kruize_helm}" -eq 1 ]]; then
+         	 kruize_helm_cleanup $NAMESPACE >> "${LOG_FILE}" 2>&1
     	fi
 
       kruize_uninstall >> "${LOG_FILE}" 2>&1
@@ -415,6 +421,8 @@ function kruize_local_demo_setup() {
 	kruize_operator=$2
 	bench2=$3
 	
+	kruize_helm=$4
+	
 	# Start all the installs
 	start_time=$(get_date)
 	echo | tee -a "${LOG_FILE}"
@@ -464,6 +472,16 @@ function kruize_local_demo_setup() {
 		fi
 	fi
 	
+	if [ "${kruize_helm}" == "1" ]; then
+		# Check for kruize pods
+		kruize_pods=$(kubectl get pod -l app=${release} -n ${NAMESPACE} 2>&1)
+
+		if [[ ! "$kruize_pods" =~ "NotFound" ]] && [[ ! "$kruize_pods" =~ "No resources" ]]; then
+			kruize_exists=true
+		fi
+	fi
+
+	
 	if [ "$operator_exists" = true ] || [ "$kruize_exists" = true ]; then
 		echo " Found!"
 		echo -n "🔄 Cleaning up existing Kruize deployment (including database)..."
@@ -482,6 +500,11 @@ function kruize_local_demo_setup() {
 			# Run operator cleanup if operator exists
 			if [ "$operator_exists" = true ]; then
 				kruize_operator_cleanup $NAMESPACE
+			fi
+			
+			if [ "${kruize_helm}" == "1" ]; then
+				echo "***** Invoking kruize helm cleanup..."
+				kruize_helm_cleanup $NAMESPACE >> "${LOG_FILE}" 2>&1
 			fi
 			
 			# Check if kruize pods still exist and call kruize_uninstall if needed (only if cluster is accessible)
@@ -568,9 +591,12 @@ function kruize_local_demo_setup() {
 	kruize_start_time=$(get_date)
 	if [[ "${kruize_operator}" -eq 1 ]]; then
 		operator_setup >> "${LOG_FILE}" 2>&1
+	elif [[ "${kruize_helm}" -eq 1 ]]; then
+		kruize_helm_setup >> "${LOG_FILE}" 2>&1
 	else
 		kruize_install >> "${LOG_FILE}" 2>&1
 	fi
+
 	install_pid=$!
 	while kill -0 $install_pid 2>/dev/null;
   	do
@@ -707,6 +733,104 @@ function kruize_local_demo_setup() {
 	if [ ${prometheus} -eq 1 ]; then
 		expose_prometheus
 	fi
+}
+
+# Setup Kruize using helm
+kruize_helm_setup() {
+	echo "Cloning kruize helm..."
+	git clone -b helm_charts_minikube https://github.com/chandrams/kruize-helm.git
+	echo "Cloning kruize helm...Done"
+
+	pushd kruize-helm
+		# Parse Kruize image and tag from KRUIZE_DOCKER_IMAGE (-i option)
+		helm_set_options=""
+		if [ -n "${KRUIZE_DOCKER_IMAGE}" ]; then
+			# Extract image repository and tag from full image string
+			kruize_image="${KRUIZE_DOCKER_IMAGE%:*}"
+			kruize_tag="${KRUIZE_DOCKER_IMAGE##*:}"
+			
+			# If no tag specified (no ':' in the string), use the whole string as image
+			if [ "${kruize_image}" == "${kruize_tag}" ]; then
+				kruize_image="${KRUIZE_DOCKER_IMAGE}"
+				kruize_tag=""
+			fi
+			
+			helm_set_options="${helm_set_options} --set kruize.image.repository=${kruize_image}"
+			if [ -n "${kruize_tag}" ]; then
+				helm_set_options="${helm_set_options} --set kruize.image.tag=${kruize_tag}"
+			fi
+		fi
+		
+		# Parse Kruize UI image and tag from KRUIZE_UI_DOCKER_IMAGE
+		if [ -n "${KRUIZE_UI_DOCKER_IMAGE}" ]; then
+			# Extract image repository and tag from full image string
+			kruize_ui_image="${KRUIZE_UI_DOCKER_IMAGE%:*}"
+			kruize_ui_tag="${KRUIZE_UI_DOCKER_IMAGE##*:}"
+			
+			# If no tag specified (no ':' in the string), use the whole string as image
+			if [ "${kruize_ui_image}" == "${kruize_ui_tag}" ]; then
+				kruize_ui_image="${KRUIZE_UI_DOCKER_IMAGE}"
+				kruize_ui_tag=""
+			fi
+			
+			helm_set_options="${helm_set_options} --set kruizeUI.image.repository=${kruize_ui_image}"
+			if [ -n "${kruize_ui_tag}" ]; then
+				helm_set_options="${helm_set_options} --set kruizeUI.image.tag=${kruize_ui_tag}"
+			fi
+		fi
+
+		# Note: --set options override values from -f (values file)
+		# This allows custom images specified via -i and -u to take precedence
+		if [ ${CLUSTER_TYPE} == "minikube" ] || [ ${CLUSTER_TYPE} == "kind" ]; then
+			helm install "${release}" charts/kruize -f charts/kruize/values-minikube.yaml -n "${NAMESPACE}" --create-namespace ${helm_set_options}
+		else
+			helm install "${release}" charts/kruize -n "${NAMESPACE}" --create-namespace ${helm_set_options}
+		fi
+	popd  # Return to original directory
+
+	echo "⏳ Waiting for all kruize pods to be ready..." 
+
+	pods=("${release}-db" "${release}" "${release}-ui-nginx")
+	labels=("${release}-db" "${release}" "${release}-ui-nginx")
+	#labels=("kruize-db" "kruize" "kruize-ui-nginx")
+	
+	# Iterate over both arrays using indices
+	for i in "${!pods[@]}"; do
+		pod="${pods[$i]}"
+		label="${labels[$i]}"
+		
+		# First wait for pod to exist
+      		timeout=180
+	      	elapsed=0
+
+		echo "pod = ${pod} label = ${label}"
+		while [ $elapsed -lt $timeout ]; do
+			if kubectl get pod -l app=${label} -n $NAMESPACE --no-headers 2>/dev/null | grep -q ${pod}; then
+				break
+			fi
+			echo -n "."
+			sleep 2
+			elapsed=$((elapsed + 2))
+		done
+
+		if [ $elapsed -ge $timeout ]; then
+			echo "❌ Timeout waiting for ${pod} pod to be created"
+			kubectl get pods -n $NAMESPACE
+			exit 1
+		fi
+		echo "⏳ Waiting for ${pod} pod to be ready..."
+		kubectl wait --for=condition=Ready pod -l app=${label} -n $NAMESPACE --timeout=600s
+		if [ $? -ne 0 ]; then
+			echo "❌ ${pod} pod failed to become ready"
+			kubectl get pods -n $NAMESPACE
+			kubectl describe pod -l app=${label} -n $NAMESPACE
+			exit 1
+		fi
+		done
+    	echo "✅ All Kruize application pods are ready!"
+
+ 	echo "✅ Deployment complete! Checking status..."
+ 	kubectl get pods -n $NAMESPACE
 }
 
 #setup the operator and deploy it
@@ -958,6 +1082,24 @@ sed -i \
         -e "s/PLACEHOLDER_NAMESPACE_NAME/$namespace/g" \
         "$namespace_json"
 
+}
+
+
+#  Kruize Helm Cleanup
+function kruize_helm_cleanup() {
+	local namespace="${1:-openshift-tuning}"
+
+	if [ "${CLUSTER_TYPE}" == "minikube" ]; then
+		minikube ssh "sudo rm -rf /data/postgres/*"
+	fi
+	
+	echo
+	echo "#######################################"
+	echo "Cleaning up Kruize helm chart"
+	echo "#######################################"
+	pushd ${current_dir}/kruize-helm
+		helm uninstall "${release}" -n ${NAMESPACE}
+	popd
 }
 
 #  Kruize Operator Cleanup

--- a/monitoring/local_monitoring/common.sh
+++ b/monitoring/local_monitoring/common.sh
@@ -738,7 +738,7 @@ function kruize_local_demo_setup() {
 # Setup Kruize using helm
 kruize_helm_setup() {
 	echo "Cloning kruize helm..."
-	git clone -b helm_charts_minikube https://github.com/chandrams/kruize-helm.git
+	git clone -b helm_charts_tests https://github.com/chandrams/kruize-helm.git
 	echo "Cloning kruize helm...Done"
 
 	pushd kruize-helm
@@ -782,9 +782,12 @@ kruize_helm_setup() {
 		# Note: --set options override values from -f (values file)
 		# This allows custom images specified via -i and -u to take precedence
 		if [ ${CLUSTER_TYPE} == "minikube" ] || [ ${CLUSTER_TYPE} == "kind" ]; then
+			echo "helm install "${release}" charts/kruize -f charts/kruize/values-minikube.yaml -n "${NAMESPACE}" --create-namespace ${helm_set_options}"
 			helm install "${release}" charts/kruize -f charts/kruize/values-minikube.yaml -n "${NAMESPACE}" --create-namespace ${helm_set_options}
 		else
-			helm install "${release}" charts/kruize -n "${NAMESPACE}" --create-namespace ${helm_set_options}
+			echo "helm install "${release}" charts/kruize -f charts/kruize/values-openshift.yaml -n "${NAMESPACE}" --create-namespace ${helm_set_options}"
+
+			helm install "${release}" charts/kruize -f charts/kruize/values-openshift.yaml -n "${NAMESPACE}" --create-namespace ${helm_set_options}
 		fi
 	popd  # Return to original directory
 

--- a/monitoring/local_monitoring/local_monitoring_demo.sh
+++ b/monitoring/local_monitoring/local_monitoring_demo.sh
@@ -30,6 +30,8 @@ export KRUIZE_DOCKER_REPO="quay.io/kruize/autotune_operator"
 # Default cluster
 export CLUSTER_TYPE="kind"
 
+export NAMESPACE="monitoring"
+
 # Target mode, default "crc"; "autotune" is currently broken
 export target="crc"
 export LOG_FILE="${current_dir}/kruize-demo.log"
@@ -38,6 +40,7 @@ KRUIZE_PORT=8080
 KRUIZE_UI_PORT=8081
 TECHEMPOWER_PORT=8082
 KRUIZE_OPERATOR=1
+KRUIZE_HELM=0
 
 function usage() {
 	echo "Usage: $0 [-s|-t] [-c cluster-type] [-f] [-i kruize-image] [-u kruize-ui-image] [-e experiment_type] [ [-b] [-m benchmark-manifests] [-n namespace] [-l] [-d load-duration] ] [-p]"
@@ -55,6 +58,7 @@ function usage() {
 	echo "d = duration to run the benchmark load"
 	echo "p = expose prometheus port"
 	echo "k = Disable operator and install kruize using deploy scripts instead."
+	echo "g = Disable operator and install kruize using helm instead."
 
 	exit 1
 }
@@ -73,8 +77,12 @@ export LOAD_DURATION="1200"
 export BENCHMARK_MANIFESTS="resource_provisioning_manifests"
 export EXPERIMENT_TYPE=""
 export KRUIZE_OPERATOR_IMAGE=""
+
+# Default helm release name
+export release="kruize"
+
 # Iterate through the commandline options
-while getopts bc:d:e:fi:klm:no:pstu: gopts
+while getopts bc:r:x:d:e:fi:kglm:no:pstu: gopts
 do
 	case "${gopts}" in
 		b)
@@ -83,6 +91,12 @@ do
 			;;
 		c)
 			CLUSTER_TYPE="${OPTARG}"
+			;;
+		r)
+			release="${OPTARG}"
+			;;
+		x)
+			NAMESPACE="${OPTARG}"
 			;;
 		d)
 			LOAD_DURATION="${OPTARG}"
@@ -124,6 +138,10 @@ do
 	 	k)
       			KRUIZE_OPERATOR=0
       			;;
+	 	g)
+      			KRUIZE_OPERATOR=0
+			KRUIZE_HELM=1
+      			;;
 		*)
 			usage
 	esac
@@ -131,10 +149,12 @@ done
 
 export demo="local"
 
-if [[ "${CLUSTER_TYPE}" == "minikube" ]] || [[ "${CLUSTER_TYPE}" == "kind" ]]; then
-    NAMESPACE="monitoring"
-else
-    NAMESPACE="openshift-tuning"
+if [ ${KRUIZE_HELM} -eq 0 ]; then
+	if [[ "${CLUSTER_TYPE}" == "minikube" ]] || [[ "${CLUSTER_TYPE}" == "kind" ]]; then
+		NAMESPACE="monitoring"
+	else
+		NAMESPACE="openshift-tuning"
+	fi
 fi
 
 if [ "${EXPERIMENT_TYPE}" == "container" ]; then
@@ -170,14 +190,14 @@ if [ ${start_demo} -eq 1 ]; then
 	  check_err "ERROR: Go pre-requisite check failed. Cannot proceed with operator deployment."
 	fi
 
-	kruize_local_demo_setup ${BENCHMARK} ${KRUIZE_OPERATOR}
+	kruize_local_demo_setup ${BENCHMARK} ${KRUIZE_OPERATOR} "" ${KRUIZE_HELM}
 	echo "For detailed logs, look in kruize-demo.log"
 	echo
 elif [ ${start_demo} -eq 2 ]; then
 	kruize_local_demo_update ${BENCHMARK}
 else
 	echo >> "${LOG_FILE}" 2>&1
-	kruize_local_demo_terminate ${KRUIZE_OPERATOR}
+	kruize_local_demo_terminate ${KRUIZE_OPERATOR} ${KRUIZE_HELM}
 	echo "For detailed logs, look in kruize-demo.log"
 	echo
 fi

--- a/monitoring/local_monitoring/local_monitoring_demo.sh
+++ b/monitoring/local_monitoring/local_monitoring_demo.sh
@@ -30,7 +30,7 @@ export KRUIZE_DOCKER_REPO="quay.io/kruize/autotune_operator"
 # Default cluster
 export CLUSTER_TYPE="kind"
 
-export NAMESPACE="monitoring"
+export NAMESPACE=""
 
 # Target mode, default "crc"; "autotune" is currently broken
 export target="crc"
@@ -149,7 +149,7 @@ done
 
 export demo="local"
 
-if [ ${KRUIZE_HELM} -eq 0 ]; then
+if [ "${NAMESPACE}" == "" ]; then
 	if [[ "${CLUSTER_TYPE}" == "minikube" ]] || [[ "${CLUSTER_TYPE}" == "kind" ]]; then
 		NAMESPACE="monitoring"
 	else


### PR DESCRIPTION
Included an option to install kruize using helm charts in Local monitoring demo

## Summary by Sourcery

Add support for installing and managing Kruize via Helm charts in the local monitoring demo alongside existing operator and script-based flows.

New Features:
- Introduce a Helm-based installation path for Kruize in the local monitoring demo, configurable via new CLI flags for release name and namespace.

Bug Fixes:
- Fix hardcoded monitoring namespace in Prometheus and Kruize port-forwarding helpers to respect the configured namespace.

Enhancements:
- Extend demo setup and teardown to detect, wait for readiness, and clean up Helm-based Kruize deployments, including database data on minikube.
- Generalize service discovery, URL resolution, and port-forwarding logic to work with both Helm-based and non-Helm Kruize services by using the configured namespace and release name.
- Improve logging of metric profile creation by echoing the curl command before execution.