### PR TITLE
[demos] Resource config updates

### DIFF
--- a/common/common_helper.sh
+++ b/common/common_helper.sh
@@ -999,14 +999,14 @@ function kruize_local_operator_bulk_demo_patch() {
 
 
   # Update kruize-db resources
-  $(SED_INPLACE) -i '/kruize-db:/,/volumeMounts:/ {
+  ${SED_INPLACE} -i '/kruize-db:/,/volumeMounts:/ {
     /requests:/,/limits:/ {
       s/cpu: ".*"/cpu: "2"/g
       s/memory: ".*"/memory: "2Gi"/g
     }
   }' ${CR_FILE}
 
-  $(SED_INPLACE) -i '/kruize-db:/,/volumeMounts:/ {
+  ${SED_INPLACE} -i '/kruize-db:/,/volumeMounts:/ {
     /limits:/,/volumeMounts:/ {
       s/cpu: ".*"/cpu: "2"/g
       s/memory: ".*"/memory: "2Gi"/g
@@ -1014,7 +1014,7 @@ function kruize_local_operator_bulk_demo_patch() {
   }' ${CR_FILE}
 
   # Update kruize application resources
-  $(SED_INPLACE) -i '/^[[:space:]]*kruize:/,$ {
+  ${SED_INPLACE} -i '/^[[:space:]]*kruize:/,$ {
     /^[[:space:]]*requests:/,/^[[:space:]]*limits:/ {
         s/cpu: ".*"/cpu: "2"/g
         s/memory: ".*"/memory: "2Gi"/g
@@ -1026,14 +1026,14 @@ function kruize_local_operator_bulk_demo_patch() {
   }' ${CR_FILE}
 
   # Update persistent volume configuration
-  $(SED_INPLACE) -i '/persistentVolume:/,/persistentVolumeClaim:/ {
+  ${SED_INPLACE} -i '/persistentVolume:/,/persistentVolumeClaim:/ {
     /capacity:/,/accessModes:/ {
       s/storage: ".*"/storage: "1Gi"/
     }
   }' ${CR_FILE}
 
   # Update persistent volume claim storage request
-  $(SED_INPLACE) -i '/persistentVolumeClaim:/,/kruize-db:/ {
+  ${SED_INPLACE} -i '/persistentVolumeClaim:/,/kruize-db:/ {
     /resources:/,/labels:/ {
       s/storage: ".*"/storage: "1Gi"/
     }

--- a/common/common_helper.sh
+++ b/common/common_helper.sh
@@ -978,9 +978,7 @@ function kruize_local_bulk_demo_patch() {
 
 # Patch Kruize Operator CR resources, currently used for Openshift Bulk demo
 function kruize_local_operator_bulk_demo_patch() {
-  OPERATOR_REPO_DIR="${KRUIZE_REPO}/kruize-operator"
-
-  CR_FILE="${OPERATOR_REPO_DIR}/config/samples/v1alpha1_kruize.yaml"
+  CR_FILE="${current_dir}/kruize-operator/config/samples/v1alpha1_kruize.yaml"
 
   if [ ! -f "${CR_FILE}" ]; then
    echo "Warning: CR file ${CR_FILE} not found, skipping resource patching"

--- a/common/common_helper.sh
+++ b/common/common_helper.sh
@@ -977,6 +977,8 @@ function kruize_local_bulk_demo_patch() {
 }
 
 # Patch Kruize Operator CR resources, currently used for Openshift Bulk demo
+# Increase PV/PVC storage to 1Gi
+# Increase Kruize/Kruize-db memory to 2Gi and 2 CPU cores
 function kruize_local_operator_bulk_demo_patch() {
   CR_FILE="${current_dir}/kruize-operator/config/samples/v1alpha1_kruize.yaml"
 

--- a/common/common_helper.sh
+++ b/common/common_helper.sh
@@ -976,3 +976,69 @@ function kruize_local_bulk_demo_patch() {
   fi
 }
 
+# Patch Kruize Operator CR resources, currently used for Openshift Bulk demo
+function kruize_local_operator_bulk_demo_patch() {
+  OPERATOR_REPO_DIR="${KRUIZE_REPO}/kruize-operator"
+
+  CR_FILE="${OPERATOR_REPO_DIR}/config/samples/v1alpha1_kruize.yaml"
+
+  if [ ! -f "${CR_FILE}" ]; then
+   echo "Warning: CR file ${CR_FILE} not found, skipping resource patching"
+   return
+  fi
+
+  echo "Patching operator CR resources in ${CR_FILE}..."
+
+  # Backup original file
+  cp "${CR_FILE}" "${CR_FILE}.bak"
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    SED_INPLACE="sed -i ''"
+  else
+    SED_INPLACE="sed -i"
+  fi
+
+
+  # Update kruize-db resources
+  $(SED_INPLACE) -i '/kruize-db:/,/volumeMounts:/ {
+    /requests:/,/limits:/ {
+      s/cpu: ".*"/cpu: "2"/g
+      s/memory: ".*"/memory: "2Gi"/g
+    }
+  }' ${CR_FILE}
+
+  $(SED_INPLACE) -i '/kruize-db:/,/volumeMounts:/ {
+    /limits:/,/volumeMounts:/ {
+      s/cpu: ".*"/cpu: "2"/g
+      s/memory: ".*"/memory: "2Gi"/g
+    }
+  }' ${CR_FILE}
+
+  # Update kruize application resources
+  $(SED_INPLACE) -i '/^[[:space:]]*kruize:/,$ {
+    /^[[:space:]]*requests:/,/^[[:space:]]*limits:/ {
+        s/cpu: ".*"/cpu: "2"/g
+        s/memory: ".*"/memory: "2Gi"/g
+    }
+    /^[[:space:]]*limits:/,$ {
+        s/cpu: ".*"/cpu: "2"/g
+        s/memory: ".*"/memory: "2Gi"/g
+    }
+  }' ${CR_FILE}
+
+  # Update persistent volume configuration
+  $(SED_INPLACE) -i '/persistentVolume:/,/persistentVolumeClaim:/ {
+    /capacity:/,/accessModes:/ {
+      s/storage: ".*"/storage: "1Gi"/
+    }
+  }' ${CR_FILE}
+
+  # Update persistent volume claim storage request
+  $(SED_INPLACE) -i '/persistentVolumeClaim:/,/kruize-db:/ {
+    /resources:/,/labels:/ {
+      s/storage: ".*"/storage: "1Gi"/
+    }
+  }' ${CR_FILE}
+
+  echo "Operator CR resources patched successfully"
+}
+

--- a/common/common_helper.sh
+++ b/common/common_helper.sh
@@ -999,14 +999,14 @@ function kruize_local_operator_bulk_demo_patch() {
 
 
   # Update kruize-db resources
-  ${SED_INPLACE} -i '/kruize-db:/,/volumeMounts:/ {
+  ${SED_INPLACE} '/kruize-db:/,/volumeMounts:/ {
     /requests:/,/limits:/ {
       s/cpu: ".*"/cpu: "2"/g
       s/memory: ".*"/memory: "2Gi"/g
     }
   }' ${CR_FILE}
 
-  ${SED_INPLACE} -i '/kruize-db:/,/volumeMounts:/ {
+  ${SED_INPLACE} '/kruize-db:/,/volumeMounts:/ {
     /limits:/,/volumeMounts:/ {
       s/cpu: ".*"/cpu: "2"/g
       s/memory: ".*"/memory: "2Gi"/g
@@ -1014,7 +1014,7 @@ function kruize_local_operator_bulk_demo_patch() {
   }' ${CR_FILE}
 
   # Update kruize application resources
-  ${SED_INPLACE} -i '/^[[:space:]]*kruize:/,$ {
+  ${SED_INPLACE} '/^[[:space:]]*kruize:/,$ {
     /^[[:space:]]*requests:/,/^[[:space:]]*limits:/ {
         s/cpu: ".*"/cpu: "2"/g
         s/memory: ".*"/memory: "2Gi"/g
@@ -1026,14 +1026,14 @@ function kruize_local_operator_bulk_demo_patch() {
   }' ${CR_FILE}
 
   # Update persistent volume configuration
-  ${SED_INPLACE} -i '/persistentVolume:/,/persistentVolumeClaim:/ {
+  ${SED_INPLACE} '/persistentVolume:/,/persistentVolumeClaim:/ {
     /capacity:/,/accessModes:/ {
       s/storage: ".*"/storage: "1Gi"/
     }
   }' ${CR_FILE}
 
   # Update persistent volume claim storage request
-  ${SED_INPLACE} -i '/persistentVolumeClaim:/,/kruize-db:/ {
+  ${SED_INPLACE} '/persistentVolumeClaim:/,/kruize-db:/ {
     /resources:/,/labels:/ {
       s/storage: ".*"/storage: "1Gi"/
     }

--- a/monitoring/local_monitoring/common.sh
+++ b/monitoring/local_monitoring/common.sh
@@ -764,10 +764,10 @@ operator_setup() {
 
 	sed -i -E 's#^([[:space:]]*)namespace:.*#\1namespace: "'"${NAMESPACE}"'"#' "./kruize-operator/config/samples/v1alpha1_kruize.yaml"
 
-	if [[ ${CLUSTER_TYPE} == "openshift" && ${demo} =="bulk" ]]; then
+	if [[ ${CLUSTER_TYPE} == "openshift" && ${demo} == "bulk" ]]; then
 	  # Patch the CR resources before deployment for openshift bulk demo
 	  kruize_local_operator_bulk_demo_patch
-	else
+	elif [[ ${CLUSTER_TYPE} == "minikube" || ${CLUSTER_TYPE} == "kind"  ]]; then
 	  # Remove optional resource config before deployment for minikube/kind demo
 	  remove_optional_cr_resource_blocks
 	fi

--- a/monitoring/local_monitoring/common.sh
+++ b/monitoring/local_monitoring/common.sh
@@ -764,17 +764,12 @@ operator_setup() {
 
 	sed -i -E 's#^([[:space:]]*)namespace:.*#\1namespace: "'"${NAMESPACE}"'"#' "./kruize-operator/config/samples/v1alpha1_kruize.yaml"
 
-	if [[ ${CLUSTER_TYPE} == "minikube" || ${CLUSTER_TYPE} == "kind" ]]; then
-	  remove_optional_cr_resource_blocks
-	fi
-
-
-	if [ [${cluster_type} == "openshift" && ${demo} =="bulk"]  ]; then
+	if [[ ${CLUSTER_TYPE} == "openshift" && ${demo} =="bulk" ]]; then
 	  # Patch the CR resources before deployment for openshift bulk demo
 	  kruize_local_operator_bulk_demo_patch
 	else
 	  # Remove optional resource config before deployment for minikube/kind demo
-	  remove_optional_cr_blocks_for_minikube
+	  remove_optional_cr_resource_blocks
 	fi
 
 	echo

--- a/monitoring/local_monitoring/common.sh
+++ b/monitoring/local_monitoring/common.sh
@@ -714,7 +714,7 @@ function kruize_local_demo_setup() {
 }
 
 #setup the operator and deploy it
-operator_setup() {
+function operator_setup() {
 #      	clone_repos kruize-operator
   git clone -b mvp_demo https://github.com/kruize/kruize-operator.git
 
@@ -1165,7 +1165,7 @@ function kruize_operator_cleanup() {
 }
 
 # Check if Go is installed and meets minimum version requirement
-check_go_prerequisite() {
+function check_go_prerequisite() {
 	echo -n "🔍 Pre-req check: Verifying Go for operator deployment..."
 
 	# Check if go is in PATH
@@ -1196,7 +1196,7 @@ check_go_prerequisite() {
 }
 
 # Patch to remove resources config from CR for minikube/kind clusters
-remove_optional_cr_resource_blocks() {
+function remove_optional_cr_resource_blocks() {
 
   local CR_FILE="${current_dir}/kruize-operator/config/samples/v1alpha1_kruize.yaml"
 

--- a/monitoring/local_monitoring/common.sh
+++ b/monitoring/local_monitoring/common.sh
@@ -715,7 +715,8 @@ function kruize_local_demo_setup() {
 
 #setup the operator and deploy it
 operator_setup() {
-      	clone_repos kruize-operator
+#      	clone_repos kruize-operator
+  git clone -b mvp_demo https://github.com/kruize/kruize-operator.git
 
 	echo "🔄 Checking for existence of $NAMESPACE namespace"
 
@@ -762,6 +763,19 @@ operator_setup() {
 	sed -i -E 's#^([[:space:]]*)cluster_type:.*#\1cluster_type: "'"${CLUSTER_TYPE}"'"#' "./kruize-operator/config/samples/v1alpha1_kruize.yaml"
 
 	sed -i -E 's#^([[:space:]]*)namespace:.*#\1namespace: "'"${NAMESPACE}"'"#' "./kruize-operator/config/samples/v1alpha1_kruize.yaml"
+
+	if [[ ${CLUSTER_TYPE} == "minikube" || ${CLUSTER_TYPE} == "kind" ]]; then
+	  remove_optional_cr_resource_blocks
+	fi
+
+
+	if [ [${cluster_type} == "openshift" && ${demo} =="bulk"]  ]; then
+	  # Patch the CR resources before deployment for openshift bulk demo
+	  kruize_local_operator_bulk_demo_patch
+	else
+	  # Remove optional resource config before deployment for minikube/kind demo
+	  remove_optional_cr_blocks_for_minikube
+	fi
 
 	echo
 	echo "📄 Applying Kruize resource..."
@@ -1184,4 +1198,38 @@ check_go_prerequisite() {
 		echo " Please upgrade Go from: https://go.dev/doc/install"
 		return 1
 	fi
+}
+
+# Patch to remove resources config from CR for minikube/kind clusters
+remove_optional_cr_resource_blocks() {
+
+  local CR_FILE="${current_dir}/kruize-operator/config/samples/v1alpha1_kruize.yaml"
+
+  if [ ! -f "${CR_FILE}" ]; then
+    echo "Warning: CR file ${CR_FILE} not found, skipping cleanup"
+    return
+  fi
+
+  echo "Removing optional CR blocks for minikube from ${CR_FILE}..."
+
+  cp "${CR_FILE}" "${CR_FILE}.bak"
+
+  awk '
+    BEGIN {
+      skip = 0
+    }
+
+    # start skipping these top-level spec children
+    /^  persistentVolume:$/      { skip = 1; next }
+    /^  persistentVolumeClaim:$/ { skip = 1; next }
+    /^  kruize-db:$/             { skip = 1; next }
+    /^  kruize:$/                { skip = 1; next }
+
+    # next top-level spec child stops skipping
+    /^  [a-zA-Z0-9_-]+:/ {
+      skip = 0
+    }
+
+    !skip { print }
+  ' "${CR_FILE}" > "${CR_FILE}.tmp" && mv "${CR_FILE}.tmp" "${CR_FILE}"
 }


### PR DESCRIPTION
This PR has the following changes:
1. Removes default resource config for minikube/kind local demo in operator mode, as similar to manifests we dont want to resource restrictions in case of minikube/kind clusters.
2. Increase the resources for Bulk OpenShift demo similar to the current manifest way of increasing the resources.

## Summary by Sourcery

Adjust Kruize operator local demo setup to remove resource constraints for minikube/kind and increase resources for the OpenShift bulk demo.

Enhancements:
- Add a helper to patch Kruize operator CR resources to higher limits for the OpenShift bulk demo.
- Introduce a script helper to strip optional resource and storage configuration from the operator CR when running on minikube or kind.
- Update local operator setup to use a specific kruize-operator demo branch and apply environment-specific CR resource handling.