### PR TITLE
Updating Wait Duration For Optimizer Demo

### DIFF
--- a/monitoring/local_monitoring/common.sh
+++ b/monitoring/local_monitoring/common.sh
@@ -29,6 +29,12 @@ OPERATOR_DEPLOYMENT_NAME="kruize-operator"
 # TODO: Remove this workaround once BULK API filters are fixed (issue #182)
 OPTIMIZER_WAIT_DURATION="${OPTIMIZER_WAIT_DURATION:-120}"
 
+# Validate OPTIMIZER_WAIT_DURATION to ensure it is a non-negative integer
+if ! [[ "${OPTIMIZER_WAIT_DURATION}" =~ ^[0-9]+$ ]]; then
+	echo "ERROR: OPTIMIZER_WAIT_DURATION must be a non-negative integer (seconds), got '${OPTIMIZER_WAIT_DURATION}'" >&2
+	exit 1
+fi
+
 function kruize_local_metric_profile() {
 	export DATASOURCE="prometheus-1"
 	export CLUSTER_NAME="default"

--- a/monitoring/local_monitoring/common.sh
+++ b/monitoring/local_monitoring/common.sh
@@ -25,6 +25,10 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 # Kruize operator deployment name constant
 OPERATOR_DEPLOYMENT_NAME="kruize-operator"
 
+# Configurable wait duration for optimizer to create experiments (in seconds)
+# TODO: Remove this workaround once BULK API filters are fixed (issue #182)
+OPTIMIZER_WAIT_DURATION="${OPTIMIZER_WAIT_DURATION:-120}"
+
 function kruize_local_metric_profile() {
 	export DATASOURCE="prometheus-1"
 	export CLUSTER_NAME="default"
@@ -1548,8 +1552,9 @@ function optimizer_demo_setup() {
 	
 	echo "✅ Kruize is available at http://${KRUIZE_URL}" >> "${LOG_FILE}" 2>&1
 
-	echo -n "⏳ Waiting for optimizer to create experiments (120s) ..."
-	sleep 120
+	echo -n "⏳ Waiting for optimizer to create experiments (${OPTIMIZER_WAIT_DURATION}s) ..."
+	# TODO: Reduce this sleep workaround once BULK API filters are fixed (issue #182)
+	sleep ${OPTIMIZER_WAIT_DURATION}
 	echo " ✅ Done!"
 
 	# Get all experiments and find the ones we're looking for

--- a/monitoring/local_monitoring/common.sh
+++ b/monitoring/local_monitoring/common.sh
@@ -1548,8 +1548,8 @@ function optimizer_demo_setup() {
 	
 	echo "✅ Kruize is available at http://${KRUIZE_URL}" >> "${LOG_FILE}" 2>&1
 
-	echo -n "⏳ Waiting for optimizer to create experiments (90s) ..."
-	sleep 90
+	echo -n "⏳ Waiting for optimizer to create experiments (120s) ..."
+	sleep 120
 	echo " ✅ Done!"
 
 	# Get all experiments and find the ones we're looking for


### PR DESCRIPTION
Changing the datasource to `thanos-1` from `prometheus-1` is causing more time to complete the job to create experiments. This results monitored workloads section to be empty during optimizer demo. This PR adds a 30 sec delay to allow kruize bulk job to be completed before checking monitored workloads. 

We aim to remove this delay, when BULK API filters are fixed and working as expected.

https://github.com/kruize/kruize-demos/issues/182 is created to track the effort.

cc: @chandrams @kusumachalasani

## Summary by Sourcery

Enhancements:
- Extend the optimizer demo experiment creation wait period from 90 seconds to 120 seconds to reduce the chance of empty monitored workloads.

## Summary by Sourcery

Enhancements:
- Introduce a configurable OPTIMIZER_WAIT_DURATION environment variable with a default of 120 seconds and use it in the optimizer demo setup to control the wait before fetching experiments.