### PR TITLE
Add an option to specify Kruize operator branch

### DIFF
--- a/monitoring/local_monitoring/ReadMe.md
+++ b/monitoring/local_monitoring/ReadMe.md
@@ -72,12 +72,13 @@ For detailed deployment options and advanced usage, see the [Advanced Users Guid
 
 ### Usage
 ```
-./local_monitoring_demo.sh [-s|-t] [-c cluster-type] [-f] [-o kruize-operator-image] [-k]
+./local_monitoring_demo.sh [-s|-t] [-c cluster-type] [-f] [-o kruize-operator-image] [-g git-branch] [-k]
   -c: Cluster type (kind, minikube, openshift)
   -s: Start demo (default)
   -t: Terminate demo
   -f: Fresh setup (kind/minikube only)
   -o: Specify custom operator image (optional). Default - quay.io/kruize/kruize-operator:<version as in Makefile>
+  -g: Specify Kruize operator git branch to clone (optional). Default - main
   -k: Disable operator and use deploy scripts instead
 ```
 

--- a/monitoring/local_monitoring/bulk_demo/README.md
+++ b/monitoring/local_monitoring/bulk_demo/README.md
@@ -49,8 +49,9 @@ u = Kruize UI Image. Default - quay.io/kruize/kruize-ui:<version as in package.j
 w = Wait for the specified seconds for metrics to be available before generating recommendations on a new cluster. Default - 0
 n = namespace of benchmark. Default - default
 d = duration to run the benchmark load
-k = install kruize using deploy scripts
 o = specify custom operator image (optional). Default - quay.io/kruize/kruize-operator:<version as in Makefile>
+g = Specify Kruize operator git branch to clone (optional). Default - main
+k = install kruize using deploy scripts
 ```
 
 **Note**: By default, Bulk demo uses operator mode with the image version from the Kruize operator Makefile: `quay.io/kruize/kruize-operator:<version>`. You can optionally specify a custom operator image using the `-o` flag.

--- a/monitoring/local_monitoring/bulk_demo/bulk_service_demo.sh
+++ b/monitoring/local_monitoring/bulk_demo/bulk_service_demo.sh
@@ -27,6 +27,9 @@ export KRUIZE_DOCKER_REPO="quay.io/kruize/autotune_operator"
 # Default operator docker image repo
 KRUIZE_OPERATOR_DOCKER_REPO="quay.io/kruize/kruize-operator"
 
+# Default operator branch
+export KRUIZE_OPERATOR_BRANCH="main"
+
 # Default cluster
 export CLUSTER_TYPE="minikube"
 
@@ -56,6 +59,7 @@ function usage() {
 	echo "n = namespace of benchmark. Default - default"
 	echo "d = duration to run the benchmark load"
 	echo "o = Kruize operator image. Default - quay.io/kruize/kruize-operator:<version as in Makefile>"
+	echo "g = Specify Kruize operator git branch to clone: -g <branch>. Default - main"
       	echo "k = install kruize using deploy scripts."
 	echo "f = create environment setup if cluster-type is minikube, kind"
 
@@ -95,7 +99,7 @@ export LOAD_DURATION="1200"
 export WAIT_TIME=0
 
 # Iterate through the commandline options
-while getopts c:i:n:d:w:klfprstu:o: gopts
+while getopts c:d:fg:i:kln:o:prstw:u: gopts
 do
 	case "${gopts}" in
 		c)
@@ -113,7 +117,10 @@ do
 		f)
 			env_setup=1
 			;;
-	  	l)
+		g)
+			export KRUIZE_OPERATOR_BRANCH="${OPTARG}"
+			;;
+		l)
 			start_demo=2
 			;;
 		s)

--- a/monitoring/local_monitoring/common.sh
+++ b/monitoring/local_monitoring/common.sh
@@ -737,8 +737,13 @@ function kruize_local_demo_setup() {
 
 #setup the operator and deploy it
 function operator_setup() {
-#      	clone_repos kruize-operator
-  git clone -b mvp_demo https://github.com/kruize/kruize-operator.git
+	clone_repos kruize-operator
+	
+	# Checkout the specified branch
+	pushd kruize-operator >/dev/null
+	git checkout ${KRUIZE_OPERATOR_BRANCH}
+	check_err "ERROR: Failed to checkout branch ${KRUIZE_OPERATOR_BRANCH}"
+	popd >/dev/null
 
 	echo "🔄 Checking for existence of $NAMESPACE namespace"
 

--- a/monitoring/local_monitoring/local_monitoring_demo.sh
+++ b/monitoring/local_monitoring/local_monitoring_demo.sh
@@ -25,6 +25,9 @@ source ${current_dir}/common.sh
 # Default operator docker image repo
 KRUIZE_OPERATOR_DOCKER_REPO="quay.io/kruize/kruize-operator"
 
+# Default operator branch
+export KRUIZE_OPERATOR_BRANCH="main"
+
 # Default docker image repo
 export KRUIZE_DOCKER_REPO="quay.io/kruize/autotune_operator"
 
@@ -48,6 +51,7 @@ function usage() {
 	echo "i = kruize image. Default - quay.io/kruize/autotune_operator:<version as in pom.xml>"
 	echo "u = Kruize UI Image. Default - quay.io/kruize/kruize-ui:<version as in package.json>"
 	echo "o = Specify custom Kruize operator image: -o <image>. Default - quay.io/kruize/kruize-operator:<version as in Makefile>"
+	echo "r = Specify Kruize operator branch to clone: -r <branch>. Default - main"
 	echo "e = supports container, namespace and gpu"
 	echo "b = deploy the benchmark."
 	echo "m = manifests of the benchmark"
@@ -75,7 +79,7 @@ export BENCHMARK_MANIFESTS="resource_provisioning_manifests"
 export EXPERIMENT_TYPE=""
 export KRUIZE_OPERATOR_IMAGE=""
 # Iterate through the commandline options
-while getopts bc:d:e:fi:klm:no:pstu: gopts
+while getopts bc:d:e:fi:klm:no:psr:tu: gopts
 do
 	case "${gopts}" in
 		b)
@@ -125,6 +129,9 @@ do
 	 	k)
       			KRUIZE_OPERATOR=0
       			;;
+		r)
+			export KRUIZE_OPERATOR_BRANCH="${OPTARG}"
+			;;
 		*)
 			usage
 	esac

--- a/monitoring/local_monitoring/local_monitoring_demo.sh
+++ b/monitoring/local_monitoring/local_monitoring_demo.sh
@@ -51,7 +51,7 @@ function usage() {
 	echo "i = kruize image. Default - quay.io/kruize/autotune_operator:<version as in pom.xml>"
 	echo "u = Kruize UI Image. Default - quay.io/kruize/kruize-ui:<version as in package.json>"
 	echo "o = Specify custom Kruize operator image: -o <image>. Default - quay.io/kruize/kruize-operator:<version as in Makefile>"
-	echo "r = Specify Kruize operator branch to clone: -r <branch>. Default - main"
+	echo "g = Specify Kruize operator git branch to clone: -g <branch>. Default - main"
 	echo "e = supports container, namespace and gpu"
 	echo "b = deploy the benchmark."
 	echo "m = manifests of the benchmark"
@@ -79,7 +79,7 @@ export BENCHMARK_MANIFESTS="resource_provisioning_manifests"
 export EXPERIMENT_TYPE=""
 export KRUIZE_OPERATOR_IMAGE=""
 # Iterate through the commandline options
-while getopts bc:d:e:fi:klm:no:psr:tu: gopts
+while getopts bc:d:e:fg:i:klm:no:pstu: gopts
 do
 	case "${gopts}" in
 		b)
@@ -97,6 +97,9 @@ do
 			;;
 		f)
 			env_setup=1
+			;;
+		g)
+			export KRUIZE_OPERATOR_BRANCH="${OPTARG}"
 			;;
 		i)
 			KRUIZE_DOCKER_IMAGE="${OPTARG}"
@@ -127,10 +130,7 @@ do
 			KRUIZE_OPERATOR_IMAGE="${OPTARG}"
 			;;
 	 	k)
-      			KRUIZE_OPERATOR=0
-      			;;
-		r)
-			export KRUIZE_OPERATOR_BRANCH="${OPTARG}"
+			KRUIZE_OPERATOR=0
 			;;
 		*)
 			usage

--- a/monitoring/local_monitoring/optimizer_demo/README.md
+++ b/monitoring/local_monitoring/optimizer_demo/README.md
@@ -31,6 +31,7 @@ The optimizer demo sets up and demonstrates Kruize Optimizers's ability to confi
 | `-i` | Custom Kruize image | `quay.io/kruize/autotune_operator:<version>` |
 | `-u` | Custom Kruize UI image | `quay.io/kruize/kruize-ui:<version>` |
 | `-o` | Custom Kruize operator image | `quay.io/kruize/kruize-operator:<version>` |
+| `-g` | Specify Kruize operator git branch to clone | `main` |
 | `-p` | Custom Kruize optimizer image | `quay.io/kruize/kruize-optimizer:0.0.1` |
 | `-n` | Namespace for benchmark | `default` |
 | `-k` | Disable operator and use deploy scripts | - |

--- a/monitoring/local_monitoring/optimizer_demo/optimizer_demo.sh
+++ b/monitoring/local_monitoring/optimizer_demo/optimizer_demo.sh
@@ -25,6 +25,9 @@ source ${local_monitoring_dir}/common.sh
 # Default operator docker image repo
 KRUIZE_OPERATOR_DOCKER_REPO="quay.io/kruize/kruize-operator"
 
+# Default operator branch
+export KRUIZE_OPERATOR_BRANCH="main"
+
 # Default docker image repo
 export KRUIZE_DOCKER_REPO="quay.io/kruize/autotune_operator"
 
@@ -47,6 +50,7 @@ function usage() {
 	echo "i = kruize image. Default - quay.io/kruize/autotune_operator:<version as in pom.xml>"
 	echo "u = Kruize UI Image. Default - quay.io/kruize/kruize-ui:<version as in package.json>"
 	echo "o = Specify custom Kruize operator image: -o <image>. Default - quay.io/kruize/kruize-operator:<version as in Makefile>"
+	echo "g = Specify Kruize operator git branch to clone: -g <branch>. Default - main"
 	echo "p = Specify custom Kruize optimizer image: -p <image>. Default - quay.io/kruize/kruize-optimizer:<version as in Deployment File>"
 	echo "n = namespace of benchmark. Default - default"
 	echo "k = Disable operator and install kruize using deploy scripts instead."
@@ -64,7 +68,7 @@ export KRUIZE_OPERATOR_IMAGE=""
 export KRUIZE_OPTIMIZER_IMAGE="quay.io/kruize/kruize-optimizer:0.0.1"
 
 # Iterate through the commandline options
-while getopts c:fi:kn:o:p:stu: gopts
+while getopts c:fg:i:kn:o:p:stu: gopts
 do
 	case "${gopts}" in
 		c)
@@ -72,6 +76,9 @@ do
 			;;
 		f)
 			env_setup=1
+			;;
+		g)
+			export KRUIZE_OPERATOR_BRANCH="${OPTARG}"
 			;;
 		i)
 			KRUIZE_DOCKER_IMAGE="${OPTARG}"

--- a/monitoring/local_monitoring/runtimes_demo/README.md
+++ b/monitoring/local_monitoring/runtimes_demo/README.md
@@ -83,6 +83,7 @@ c = supports minikube, kind and openshift cluster-type
 f = create environment setup if cluster-type is minikube, kind
 i = kruize image. Default - quay.io/kruize/autotune_operator:<version as in pom.xml>
 o = Kruize operator image. Default - quay.io/kruize/kruize-operator:<version as in Makefile>
+g = Specify Kruize operator git branch to clone. Default - main
 u = kruize ui image. Default - quay.io/kruize/kruize-ui:<version as in package.json>
 k = Disable operator and install kruize using deploy scripts instead.
 n = namespace where benchmarks deploys. Default - default

--- a/monitoring/local_monitoring/runtimes_demo/runtimes_demo.sh
+++ b/monitoring/local_monitoring/runtimes_demo/runtimes_demo.sh
@@ -25,6 +25,9 @@ source ${current_dir}/../common.sh
 KRUIZE_OPERATOR_DOCKER_REPO="quay.io/kruize/kruize-operator"
 export NAMESPACE="openshift-tuning"
 
+# Default operator branch
+export KRUIZE_OPERATOR_BRANCH="main"
+
 # Default docker image repo
 export KRUIZE_DOCKER_REPO="quay.io/kruize/autotune_operator"
 
@@ -49,6 +52,7 @@ function usage() {
 	echo "i = kruize image. Default - quay.io/kruize/autotune_operator:<version as in pom.xml>"
 	echo "u = Kruize UI Image. Default - quay.io/kruize/kruize-ui:<version as in package.json>"
 	echo "o = Kruize operator image. Default - quay.io/kruize/kruize-operator:<version as in Makefile>"
+	echo "g = Specify Kruize operator git branch to clone: -g <branch>. Default - main"
 	echo "n = namespace of benchmark. Default - default"
 	echo "p = expose prometheus port"
 	echo "k = Disable operator and install kruize using deploy scripts instead."
@@ -68,7 +72,7 @@ export EXPERIMENT_TYPE=""
 export KRUIZE_OPERATOR_IMAGE=""
 
 # Iterate through the commandline options
-while getopts c:kfi:no:pstu: gopts
+while getopts c:fg:i:kn:o:pstu: gopts
 do
 	case "${gopts}" in
 		c)
@@ -76,6 +80,9 @@ do
 			;;
 		f)
 			env_setup=1
+			;;
+		g)
+			export KRUIZE_OPERATOR_BRANCH="${OPTARG}"
 			;;
 		i)
 			KRUIZE_DOCKER_IMAGE="${OPTARG}"

--- a/monitoring/local_monitoring/vpa_demo/README.md
+++ b/monitoring/local_monitoring/vpa_demo/README.md
@@ -41,6 +41,7 @@ s = start (default), t = terminate
 u = Kruize UI Image. Default - quay.io/kruize/kruize-ui:<version as in package.json>
 n = namespace of benchmark. Default - default
 o = Specify custom operator image (optional). Default - quay.io/kruize/kruize-operator:<version as in Makefile>
+g = Specify Kruize operator git branch to clone (optional). Default - main
 k = Disable operator and use deploy scripts instead
 ```
 

--- a/monitoring/local_monitoring/vpa_demo/vpa_demo.sh
+++ b/monitoring/local_monitoring/vpa_demo/vpa_demo.sh
@@ -27,6 +27,9 @@ export KRUIZE_DOCKER_REPO="quay.io/kruize/autotune_operator"
 # Default operator docker image repo
 KRUIZE_OPERATOR_DOCKER_REPO="quay.io/kruize/kruize-operator"
 
+# Default operator branch
+export KRUIZE_OPERATOR_BRANCH="main"
+
 # Default cluster
 export CLUSTER_TYPE="kind"
 
@@ -47,6 +50,7 @@ function usage() {
 	echo "i = kruize image. Default - quay.io/kruize/autotune_operator:<version as in pom.xml>"
 	echo "u = Kruize UI Image. Default - quay.io/kruize/kruize-ui:<version as in package.json>"
 	echo "o = Specify custom Kruize operator image: -o <image>. Default - quay.io/kruize/kruize-operator:<version as in Makefile>"
+	echo "g = Specify Kruize operator git branch to clone: -g <branch>. Default - main"
 	echo "b = deploy the benchmark."
 	echo "m = manifests of the benchmark"
 	echo "n = namespace of benchmark. Default - default"
@@ -72,7 +76,7 @@ export LOAD_DURATION="1200"
 export BENCHMARK_MANIFESTS="resource_provisioning_manifests"
 export EXPERIMENT_TYPE=""
 # Iterate through the commandline options
-while getopts bc:d:e:kfi:lm:n:pstu:o: gopts
+while getopts bc:d:e:fg:i:klm:n:o:pstu: gopts
 do
 	case "${gopts}" in
 		b)
@@ -87,6 +91,9 @@ do
 			;;
 		f)
 			env_setup=1
+			;;
+		g)
+			export KRUIZE_OPERATOR_BRANCH="${OPTARG}"
 			;;
 		i)
 			KRUIZE_DOCKER_IMAGE="${OPTARG}"


### PR DESCRIPTION
This PR adds `-g` flag option to pass Kruize operator branch in the local monitoring demos. Mainly to ensure the default stable `main` branch can be used by end users and any other branch(for eg: `mvp_demo` branch changes) can be used for internal testing.

## Summary by Sourcery

Add support for selecting the Kruize operator Git branch in local monitoring demos and default it to main.

New Features:
- Allow specifying the Kruize operator branch via an -r flag in the local monitoring demo script.

Enhancements:
- Clone the kruize-operator repository generically and checkout the configured branch instead of hardcoding a specific branch.