### PR TITLE
disable local parameter for kruize in remote mode

### DIFF
--- a/common/common_helper.sh
+++ b/common/common_helper.sh
@@ -954,8 +954,10 @@ function setup_workload() {
 function kruize_local_disable() {
 	if [[ ${CLUSTER_TYPE} == "minikube" || ${CLUSTER_TYPE} == "kind" ]]; then
 		sed -i 's/"isROSEnabled": "false"/"isROSEnabled": "true"/' manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
+		sed -i 's/"local": "true"/"local": "false"/' manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml
 	elif [ ${CLUSTER_TYPE} == "openshift" ]; then
 	  sed -i 's/"isROSEnabled": "false"/"isROSEnabled": "true"/' manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
+	  sed -i 's/"local": "true"/"local": "false"/' manifests/crc/default-db-included-installation/openshift/kruize-crc-openshift.yaml
 	fi
 }
 


### PR DESCRIPTION
This PR will ensure that `local` parameter in config is set to `false` when Kruize is deployed in remote monitoring mode. This is needed because, we are unifying API endpoint for generating recommendations for local and remote mode in Kruize and functionality depend on `local` config param. So, ensuring that it is `false` in remote monitoring mode is important.

## Summary by Sourcery

Bug Fixes:
- Force the Kruize "local" configuration flag to false in remote monitoring installations for minikube and OpenShift clusters to align behavior with unified recommendation APIs.